### PR TITLE
Add settings page/panel to about:addons

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -52,6 +52,11 @@
     }
   ],
 
+  "options_ui": {
+    "page": "settings.html",
+    "browser_style": true
+  },
+
   "permissions": [
       "<all_urls>",
       "storage",

--- a/src/settings.html
+++ b/src/settings.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8"/>
+    <title>Firefox Relay</title>
+    <!-- <link rel="stylesheet" href="/css/relay.css" />
+    <link rel="stylesheet" href = "/css/first-run.css" /> -->
+    <script src="/js/data-opt-out-toggle.js"></script>
+    <script src="/js/metrics.js"></script>
+    <script src="/js/first-run.js"></script>
+  </head>
+  <body>
+    <h1>Firefox Relay</h1>
+    <main>
+        <section>
+            <h2>Settings</h2>
+            <ul>
+                <li>
+                    <input type="checkbox">
+                    <span>Show Relay icon in email fields on websites</span>
+                </li>
+                <li>
+                    <input type="checkbox">
+                    <span>Allow Mozilla to collect interaction data</span>
+                </li>
+            </ul>
+        </section>
+        <section>
+            <h2>Data Collection</h2>
+            <div>
+                <div>
+                    <input type="checkbox">
+                    <span>Allow Mozilla to collect information about how you use this extension.</span>
+                </div>
+                <p>Collecting interaction data when you do things like click the Relay icon in your toolbar or create a new alias helps us learn what is working well and where we can improve. You can always turn this off in the Settings panel.</p>
+            </div>
+        </section>
+
+        <section>
+            <h2>Links</h2>
+            <ul>
+                <li>
+                    <a href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay-addon&utm_medium=popup"  data-event-action="click" data-event-label="panel-leave-feedback-link">Leave Feedback</a>
+                </li>
+                <li>
+                    <a href="https://www.mozilla.org/privacy/firefox-relay/?utm_source=fx-relay-addon&utm_medium=popup"  data-event-action="click" data-event-label="panel-privacy-link">Privacy</a>
+                </li>
+                <li>
+                    <a href="https://www.mozilla.org/about/legal/terms/firefox-relay/?utm_source=fx-relay-addon&utm_medium=popup"  data-event-action="click" data-event-label="panel-terms-of-service">Terms of Service</a>
+                </li>
+            </ul>
+        </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
### Summary:

This PR exposes settings from the pop-up into the preferences pane on `about:addons`. 

### Screenshots (WIP): 

<img width="708" alt="image" src="https://user-images.githubusercontent.com/2692333/122078710-67937a80-cdc2-11eb-8399-87d47b42f742.png">
