### PR TITLE
start i18n

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,0 +1,81 @@
+{
+    "extensionDescription": {
+        "message": "Firefox Relay makes it easy to create email aliases that forward to your real inbox. Use it to protect your online accounts from hackers and unwanted messages.",
+        "description": "Description of the extension. DO NOT TRANSLATE \"Firefox Relay\"."
+    },
+    "firstRunP": {
+        "message": "Sie haben das Firefox Relay-Add-on erfolgreich installiert. Melden Sie sich zunächst mit Ihrem Firefox-Konto bei Relay an."
+    },
+    "firstRunCollectDataLabel": {
+        "message": "Erlauben Sie Mozilla, Informationen darüber zu sammeln, wie Sie diese Erweiterung verwenden."
+    },
+    "disableDataCollection": {
+        "message": "Datensammlung deaktivieren"
+    },
+    "firstRunPrefP": {
+        "message": "Das Sammeln von Interaktionsdaten, wenn Sie beispielsweise auf das Relais-Symbol in Ihrer Symbolleiste klicken oder einen neuen Alias erstellen, hilft uns zu erfahren, was gut funktioniert und wo wir uns verbessern können. Sie können dies jederzeit im Einstellungsfenster deaktivieren."
+    },
+    "firstRunSignInButton": {
+        "message": "Anmelden"
+    },
+    "popupSettingsTitle": {
+        "message": "die Einstellungen"
+    },
+    "popupSettingsReturn": {
+        "message": "Zurück zum Hauptfenster"
+    },
+    "popupSettingsShowIcon": {
+        "message": "Relaissymbol in E-Mail-Feldern auf Websites anzeigen"
+    },
+    "popupSettingsCollectData": {
+        "message": "Erlauben Sie Mozilla, Interaktionsdaten zu sammeln"
+    },
+    "popupSettingsLeaveFeedback": {
+        "message": "Hinterlasse Kommentar"
+    },
+    "popupSettingsPrivacy": {
+        "message": "Privatsphäre"
+    },
+    "popupSettingsTermsOfService": {
+        "message": "Nutzungsbedingungen"
+    },
+    "popupSignUpPanelWelcome": {
+        "message": "Willkommen"
+    },
+    "popupSignUpPanelIntro": {
+        "message": "Melden Sie sich zunächst mit Ihrem Firefox-Konto bei Relay an."
+    },
+    "popupSignUpPanelContinue": {
+        "message": "Fortsetzen"
+    },
+    "popupOnboardingShowPrevious": {
+        "message": "Vorheriges Panel anzeigen"
+    },
+    "popupOnboardingShowNext": {
+        "message": "Gehe zum nächsten Panel"
+    },
+    "popupOnboardingManageAll": {
+        "message": "Alle Aliase verwalten"
+    },
+    "popupOnboardingPanel1Body": {
+        "message": "Wenn das Firefox Relay-Symbol auf einer Website angezeigt wird, wählen Sie es aus, um einen neuen Alias zu generieren."
+    },
+    "popupOnboardingPanel2Headline": {
+        "message": "Sie sehen das Symbol nicht?"
+    },
+    "popupOnboardingPanel2Body": {
+        "message": "Klicken Sie mit der rechten Maustaste (Windows) bzw. bei gedrückter Strg-Taste (macOS) auf Formularfelder, um auf das Kontextmenü zuzugreifen und von dort aus einen Alias zu generieren."
+    },
+    "popupOnboardingPanel3Headline": {
+        "message": "Erhalten Sie zu viele E-Mails?"
+    },
+    "popupOnboardingPanel3Body": {
+        "message": "Verwalten Sie Ihre Relay-Aliasnamen und schalten Sie die Weiterleitung einfach auf Blockieren um."
+    },
+    "popupOnboardingMaxAliasesPanelHeadline": {
+        "message": "Gib mir fünf!"
+    },
+    "popupOnboardingMaxAliasesPanelBody": {
+        "message": "Sie sind ein Firefox Relay-Power-User!"
+    }
+}

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -66,7 +66,7 @@
     "popupOnboardingShowNext": {
         "message": "Gehe zum nächsten Panel"
     },
-    "popupOnboardingManageAll": {
+    "ManageAllAliases": {
         "message": "Alle Aliase verwalten"
     },
     "popupOnboardingPanel1Body": {
@@ -89,5 +89,29 @@
     },
     "popupOnboardingMaxAliasesPanelBody": {
         "message": "Sie sind ein Firefox Relay-Power-User!"
+    },
+    "pageInputIconSignUpText": {
+        "message": "Besuchen Sie die Firefox Relay-Website, um sich anzumelden oder ein Konto zu erstellen."
+    },
+    "pageInputIconSignUpButton": {
+        "message": "Gehe zu Firefox Relay"
+    },
+    "pageInputIconGenerateNewAlias": {
+        "message": "Neuen Alias generieren"
+    },
+    "pageInputIconMaxAliasesError": {
+        "message": "Sie haben bereits $MAX$-Aliasnamen erstellt",
+        "description": "Tells the user they have already created the max number of aliases.",
+        "placeholders": {
+            "max": {
+                "content": "$1"
+            }
+        }
+    },
+    "pageFillRelayAddressLimit": {
+        "message": "Sie haben das Alias-Limit erreicht."
+    },
+    "close": {
+        "message": "Schließen"
     }
 }

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -48,6 +48,18 @@
     "popupSignUpPanelContinue": {
         "message": "Fortsetzen"
     },
+    "popupRemainingAliases": {
+        "message": "Sie haben $REMAINING$/$MAX$ verbleibende Aliasse",
+        "description": "Tells the user how many more aliases they can make.",
+        "placeholders": {
+            "remaining": {
+                "content": "$1"
+            },
+            "max": {
+                "content": "$2"
+            }
+        }
+    },
     "popupOnboardingShowPrevious": {
         "message": "Vorheriges Panel anzeigen"
     },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -66,7 +66,7 @@
     "popupOnboardingShowNext": {
         "message": "Go to next panel"
     },
-    "popupOnboardingManageAll": {
+    "ManageAllAliases": {
         "message": "Manage All Aliases"
     },
     "popupOnboardingPanel1Body": {
@@ -89,5 +89,29 @@
     },
     "popupOnboardingMaxAliasesPanelBody": {
         "message": "You’re a Firefox Relay power user!"
+    },
+    "pageInputIconSignUpText": {
+        "message": "Visit the Firefox Relay website to sign in or create an account."
+    },
+    "pageInputIconSignUpButton": {
+        "message": "Go to Firefox Relay"
+    },
+    "pageInputIconGenerateNewAlias": {
+        "message": "Generate New Alias"
+    },
+    "pageInputIconMaxAliasesError": {
+        "message": "You have already created $MAX$ aliases",
+        "description": "Tells the user they have already created the max number of aliases.",
+        "placeholders": {
+            "max": {
+                "content": "$1"
+            }
+        }
+    },
+    "pageFillRelayAddressLimit": {
+        "message": "You've reached the alias limit."
+    },
+    "close": {
+        "message": "Close"
     }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -48,6 +48,18 @@
     "popupSignUpPanelContinue": {
         "message": "Continue"
     },
+    "popupRemainingAliases": {
+        "message": "You have $REMAINING$/$MAX$ remaining aliases",
+        "description": "Tells the user how many more aliases they can make.",
+        "placeholders": {
+            "remaining": {
+                "content": "$1"
+            },
+            "max": {
+                "content": "$2"
+            }
+        }
+    },
     "popupOnboardingShowPrevious": {
         "message": "Show previous panel"
     },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,0 +1,81 @@
+{
+    "extensionDescription": {
+        "message": "Firefox Relay makes it easy to create email aliases that forward to your real inbox. Use it to protect your online accounts from hackers and unwanted messages.",
+        "description": "Description of the extension. DO NOT TRANSLATE \"Firefox Relay\"."
+    },
+    "firstRunP": {
+        "message": "You’ve successfully installed the Firefox Relay add-on. To get started, sign in to Relay with your Firefox account."
+    },
+    "firstRunCollectDataLabel": {
+        "message": "Allow Mozilla to collect information about how you use this extension."
+    },
+    "disableDataCollection": {
+        "message": "Disable data collection"
+    },
+    "firstRunPrefP": {
+        "message": "Collecting interaction data when you do things like click the Relay icon in your toolbar or create a new alias helps us learn what is working well and where we can improve. You can always turn this off in the Settings panel."
+    },
+    "firstRunSignInButton": {
+        "message": "Sign Up / In"
+    },
+    "popupSettingsTitle": {
+        "message": "Settings"
+    },
+    "popupSettingsReturn": {
+        "message": "Return to main panel"
+    },
+    "popupSettingsShowIcon": {
+        "message": "Show Relay icon in email fields on websites"
+    },
+    "popupSettingsCollectData": {
+        "message": "Allow Mozilla to collect interaction data"
+    },
+    "popupSettingsLeaveFeedback": {
+        "message": "Leave Feedback"
+    },
+    "popupSettingsPrivacy": {
+        "message": "Privacy"
+    },
+    "popupSettingsTermsOfService": {
+        "message": "Terms of Service"
+    },
+    "popupSignUpPanelWelcome": {
+        "message": "Welcome"
+    },
+    "popupSignUpPanelIntro": {
+        "message": "Get started by signing in to Relay with your Firefox account."
+    },
+    "popupSignUpPanelContinue": {
+        "message": "Continue"
+    },
+    "popupOnboardingShowPrevious": {
+        "message": "Show previous panel"
+    },
+    "popupOnboardingShowNext": {
+        "message": "Go to next panel"
+    },
+    "popupOnboardingManageAll": {
+        "message": "Manage All Aliases"
+    },
+    "popupOnboardingPanel1Body": {
+        "message": "When the Firefox Relay icon appears on a website, select it to generate a new alias."
+    },
+    "popupOnboardingPanel2Headline": {
+        "message": "Don't see the icon?"
+    },
+    "popupOnboardingPanel2Body": {
+        "message": "Right-click (Windows) or Control-click (macOS) on form fields to access the context menu and generate an alias from there."
+    },
+    "popupOnboardingPanel3Headline": {
+        "message": "Getting too many emails?"
+    },
+    "popupOnboardingPanel3Body": {
+        "message": "Manage your Relay aliases and easily toggle Forwarding to Blocking."
+    },
+    "popupOnboardingMaxAliasesPanelHeadline": {
+        "message": "High five!"
+    },
+    "popupOnboardingMaxAliasesPanelBody": {
+        "message": "You’re a Firefox Relay power user!"
+    }
+}

--- a/src/first-run.html
+++ b/src/first-run.html
@@ -5,6 +5,7 @@
     <title>Firefox Relay</title>
     <link rel="stylesheet" href="/css/relay.css" />
     <link rel="stylesheet" href = "/css/first-run.css" />
+    <script src="/js/i18n.js"></script>
     <script src="/js/data-opt-out-toggle.js"></script>
     <script src="/js/metrics.js"></script>
     <script src="/js/first-run.js"></script>
@@ -16,13 +17,13 @@
       <div class="first-run-content">
         <h1 class="first-run-h1 fx-relay-font-met show-700">Firefox Relay</h1>
         <div class="first-run-copy-wrapper">
-          <p class="first-run-p">You’ve successfully installed the Firefox Relay add-on. To get started, sign in to Relay with your Firefox account.</p>
+          <p class="first-run-p i18n-content" data-i18n-message-id="firstRunP"></p>
           <div class="collection-options">
-            <span class="setting-label flex-col">Allow Mozilla to collect information about how you use this extension.</span>
+            <span class="setting-label flex-col i18n-content" data-i18n-message-id="firstRunCollectDataLabel"></span>
             <button title="" class="data-collection fx-relay-toggle"></button>
           </div>
-          <p class="pref-p">Collecting interaction data when you do things like click the Relay icon in your toolbar or create a new alias helps us learn what is working well and where we can improve. You can always turn this off in the Settings panel.</p>
-          <button id="first-run-sign-in" class="first-run-sign-in open-oauth" data-event-label="first-run-sign-in">Sign Up / In</button>
+          <p class="pref-p i18n-content" data-i18n-message-id="firstRunPrefP"></p>
+          <button id="first-run-sign-in" class="first-run-sign-in open-oauth i18n-content" data-event-label="first-run-sign-in" data-i18n-message-id="firstRunSignInButton"></button>
         </div>
       </div>
     </main>

--- a/src/js/add_input_icon.js
+++ b/src/js/add_input_icon.js
@@ -173,11 +173,11 @@ async function addRelayIconToInput(emailInput) {
 
     if (!signedInUser) {
       const signUpMessageEl = createElementWithClassList("span", "fx-relay-menu-sign-up-message");
-      signUpMessageEl.textContent = "Visit the Firefox Relay website to sign in or create an account.";
+      signUpMessageEl.textContent = browser.i18n.getMessage("pageInputIconSignUpText");
 
       relayInPageMenu.appendChild(signUpMessageEl);
       const signUpButton = createElementWithClassList("button", "fx-relay-menu-sign-up-btn");
-      signUpButton.textContent = "Go to Firefox Relay";
+      signUpButton.textContent = browser.i18n.getMessage("pageInputIconSignUpButton");
 
       signUpButton.addEventListener("click", async(clickEvt) => {
         preventDefaultBehavior(clickEvt);
@@ -197,7 +197,7 @@ async function addRelayIconToInput(emailInput) {
     sendInPageEvent("viewed-menu", "authenticated-user-input-menu")
     // Create "Generate Relay Address" button
     const generateAliasBtn = createElementWithClassList("button", "fx-relay-menu-generate-alias-btn");
-    generateAliasBtn.textContent = "Generate New Alias";
+    generateAliasBtn.textContent = browser.i18n.getMessage("pageInputIconGenerateNewAlias");
 
 
 
@@ -208,7 +208,7 @@ async function addRelayIconToInput(emailInput) {
 
     const numAliasesRemaining = maxNumAliases - relayAddresses.length;
     const aliases = (numAliasesRemaining === 1) ? "alias" : "aliases";
-    remainingAliasesSpan.textContent = `You have ${numAliasesRemaining} ${aliases} remaining`;
+    remainingAliasesSpan.textContent = browser.i18n.getMessage("popupRemainingAliases", [numAliasesRemaining, maxNumAliases]);
 
     const maxNumAliasesReached = numAliasesRemaining === 0;
     if (maxNumAliasesReached) {
@@ -219,7 +219,7 @@ async function addRelayIconToInput(emailInput) {
 
     // Create "Manage All Aliases" link
     const relayMenuDashboardLink = createElementWithClassList("a", "fx-relay-menu-dashboard-link");
-    relayMenuDashboardLink.textContent = "Manage All Aliases";
+    relayMenuDashboardLink.textContent = browser.i18n.getMessage("ManageAllAliases");
     relayMenuDashboardLink.href = `${relaySiteOrigin}?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=manage-all-addresses`;
     relayMenuDashboardLink.target = "_blank";
     relayMenuDashboardLink.addEventListener("click", () => {
@@ -260,7 +260,7 @@ async function addRelayIconToInput(emailInput) {
         });
 
         const errorMessage = createElementWithClassList("p", "fx-relay-error-message");
-        errorMessage.textContent = `You have already created ${maxNumAliases} aliases`;
+        errorMessage.textContent = browser.i18n.getMessage("pageInputIconMaxAliasesError");
 
         relayInPageMenu.insertBefore(errorMessage, relayMenuDashboardLink);
         return;

--- a/src/js/data-opt-out-toggle.js
+++ b/src/js/data-opt-out-toggle.js
@@ -8,7 +8,7 @@ async function enableDataOptOut() {
   const stylePrefToggle = (userPref) => {
     if (userPref === "data-enabled") {
       dataCollectionPrefToggle.classList.remove("data-disabled");
-      dataCollectionPrefToggle.title = "Disable data collection";
+      dataCollectionPrefToggle.title = browser.i18n.getMessage("disableDataCollection");
       dataCollectionPrefToggle.dataset.collectionPreference = "data-disabled";
       return;
     }

--- a/src/js/fill_relay_address.js
+++ b/src/js/fill_relay_address.js
@@ -23,12 +23,12 @@ async function showModal(modalType) {
   sendModalEvent("viewed-modal", "modal-max-aliases");
   const modalMessage = document.createElement("span");
 
-  modalMessage.textContent = "You've reached the alias limit.";
+  modalMessage.textContent = browser.i18n.getMessage("pageFillRelayAddressLimit");
   modalMessage.classList = ["fx-relay-modal-message"];
   modalContent.appendChild(modalMessage);
 
   const manageAliasesLink = document.createElement("a");
-  manageAliasesLink.textContent = "Manage All Aliases";
+  manageAliasesLink.textContent = browser.i18n.getMessage("ManageAllAliases");
   manageAliasesLink.classList = ["fx-relay-new-tab fx-relay-modal-manage-aliases"];
   manageAliasesLink.href = `${relaySiteOrigin}?utm_source=fx-relay-addon&utm_medium=context-menu-modal&utm_content=manage-relay-addresses`;
 
@@ -42,7 +42,7 @@ async function showModal(modalType) {
 
   const modalCloseButton = document.createElement("button");
   modalCloseButton.classList = ["fx-relay-modal-close-button"];
-  modalCloseButton.textContent = "Close";
+  modalCloseButton.textContent = browser.i18n.getMessage("close");
 
   // Remove relay modal on button click
   modalCloseButton.addEventListener("click", () => {

--- a/src/js/first-run.js
+++ b/src/js/first-run.js
@@ -18,4 +18,5 @@ document.addEventListener("DOMContentLoaded", async () => {
       return window.open(`${relaySiteOrigin}/accounts/profile?utm_source=fx-relay-addon&utm_medium=first-run&utm_content=first-run-sign-up-btn`);
     });
   });
+
 });

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -1,0 +1,10 @@
+document.addEventListener("DOMContentLoaded", async () => {
+  const i18nContentElements = document.querySelectorAll(".i18n-content");
+  i18nContentElements.forEach(el => {
+    el.textContent = browser.i18n.getMessage(el.dataset.i18nMessageId);
+  });
+  const i18nContentAttributes = document.querySelectorAll(".i18n-attribute");
+  i18nContentAttributes.forEach(el => {
+    el.setAttribute(el.dataset.i18nAttribute, browser.i18n.getMessage(el.dataset.i18nMessageId));
+  });
+});

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -52,12 +52,9 @@ async function showRelayPanel(tipPanelToShow) {
   };
 
   const { relayAddresses, maxNumAliases } = await getRemainingAliases();
-  const remainingAliasMessage = document.querySelector(".aliases-remaining");
-  const numRemainingEl = remainingAliasMessage.querySelector(".num-aliases-remaining");
   const numRemaining = maxNumAliases - relayAddresses.length;
-  const maxNumAliasesEl = remainingAliasMessage.querySelector(".max-num-aliases");
-  maxNumAliasesEl.textContent = `/${maxNumAliases}`;
-  numRemainingEl.textContent = numRemaining;
+  const remainingAliasMessage = document.querySelector(".aliases-remaining");
+  remainingAliasMessage.textContent = browser.i18n.getMessage("popupRemainingAliases", [numRemaining, maxNumAliases]);
 
   document.body.classList.add("relay-panel");
   updatePanel(numRemaining, tipPanelToShow);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -2,23 +2,23 @@ function getOnboardingPanels() {
   return {
     "panel1": {
       "imgSrc": "tip1-icon.svg",
-      "tipHeadline": "Welcome!",
-      "tipBody": "When the Firefox Relay icon appears on a website, select it to generate a new alias.",
+      "tipHeadline": browser.i18n.getMessage("popupSignUpPanelWelcome"),
+      "tipBody": browser.i18n.getMessage("popupOnboardingPanel1Body"),
     },
     "panel2": {
       "imgSrc": "tip2-icon.svg",
-      "tipHeadline": "Don't see the icon?",
-      "tipBody":"Right-click (Windows) or Control-click (macOS) on form fields to access the context menu and generate an alias from there.",
+      "tipHeadline": browser.i18n.getMessage("popupOnboardingPanel2Headline"),
+      "tipBody": browser.i18n.getMessage("popupOnboardingPanel2Body"),
     },
     "panel3": {
       "imgSrc": "tip3-icon.svg",
-      "tipHeadline": "Getting too many emails?",
-      "tipBody":"Manage your Relay aliases and easily toggle Forwarding to Blocking.",
+      "tipHeadline": browser.i18n.getMessage("popupOnboardingPanel3Headline"),
+      "tipBody": browser.i18n.getMessage("popupOnboardingPanel3Body"),
     },
     "maxAliasesPanel": {
       "imgSrc": "high-five.svg",
-      "tipHeadline": "High five!",
-      "tipBody": "You’re a Firefox Relay power user!",
+      "tipHeadline": browser.i18n.getMessage("popupOnboardingMaxAliasesPanelHeadline"),
+      "tipBody": browser.i18n.getMessage("popupOnboardingMaxAliasesPanelBody"),
     },
   };
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,9 @@
   "name": "Firefox Relay",
   "version": "1.5.1",
 
-  "description": "Firefox Relay makes it easy to create email aliases that forward to your real inbox. Use it to protect your online accounts from hackers and unwanted messages.",
+  "description": "__MSG_extensionDescription__",
+
+  "default_locale": "en",
 
   "icons": {
     "48": "icons/placeholder-logo.png"

--- a/src/popup.html
+++ b/src/popup.html
@@ -5,6 +5,7 @@
     <title>Firefox Relay</title>
     <link rel="stylesheet" href="css/relay.css">
     <link rel="stylesheet" href="css/popup.css">
+    <script src="/js/i18n.js"></script>
     <script src="/js/data-opt-out-toggle.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/popup.js"></script>
@@ -15,39 +16,35 @@
       <fx-relay-logo-wrapper>
         <fx-relay-logomark></fx-relay-logomark>
         <fx-relay-logotype></fx-relay-logotype>
-        <button class="open-settings settings-toggle" title="Settings"></button>
+        <button class="open-settings settings-toggle i18n-attribute" data-i18n-attribute="title" data-i18n-message-id="popupSettingsTitle"></button>
       </fx-relay-logo-wrapper>
 
       <settings>
         <div class="settings-header">
-          <button class="close-settings settings-toggle" title="Return to main panel"></button>
-          <h1 class="settings-hl">Settings</h1>
+          <button class="close-settings settings-toggle i18n-attribute" data-i18n-attribute="title" data-i18n-message-id="popupSettingsReturn"></button>
+          <h1 class="settings-hl i18n-content" data-i18n-message-id="popupSettingsTitle"></h1>
         </div>
         <ul class="settings-list">
           <li class="setting">
-            <span class="setting-label flex-col">Show Relay icon in email fields on websites</span>
+            <span class="setting-label flex-col i18n-content" data-i18n-message-id="popupSettingsShowIcon"></span>
             <button title="" data-icon-visibility-option="disable-input-icon" class="toggle-icon-in-page-visibility fx-relay-toggle"></button>
           </li>
           <li class="setting">
-            <span class="setting-label flex-col">Allow Mozilla to collect interaction data</span>
+            <span class="setting-label flex-col i18n-content" data-i18n-message-id="popupSettingsCollectData"></span>
             <button title="" class="data-collection fx-relay-toggle"></button>
           </li>
           <li class="setting flex-col">
-            <a href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay-addon&utm_medium=popup" class="setting-label setting-link close-popup-after-click" data-event-action="click" data-event-label="panel-leave-feedback-link">Leave Feedback</a>
-            <a href="https://www.mozilla.org/privacy/firefox-relay/?utm_source=fx-relay-addon&utm_medium=popup" class="setting-label setting-link close-popup-after-click" data-event-action="click" data-event-label="panel-privacy-link">Privacy</a>
-            <a href="https://www.mozilla.org/about/legal/terms/firefox-relay/?utm_source=fx-relay-addon&utm_medium=popup" class="setting-label setting-link close-popup-after-click" data-event-action="click" data-event-label="panel-terms-of-service">Terms of Service</a>
+            <a href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay-addon&utm_medium=popup" class="setting-label setting-link close-popup-after-click i18n-content" data-event-action="click" data-event-label="panel-leave-feedback-link" data-i18n-message-id="popupSettingsLeaveFeedback"></a>
+            <a href="https://www.mozilla.org/privacy/firefox-relay/?utm_source=fx-relay-addon&utm_medium=popup" class="setting-label setting-link close-popup-after-click i18n-content" data-event-action="click" data-event-label="panel-privacy-link" data-i18n-message-id="popupSettingsPrivacy"></a>
+            <a href="https://www.mozilla.org/about/legal/terms/firefox-relay/?utm_source=fx-relay-addon&utm_medium=popup" class="setting-label setting-link close-popup-after-click i18n-content" data-event-action="click" data-event-label="panel-terms-of-service" data-i18n-message-id="popupSettingsTermsOfService"></a>
           </li>
         </ul>
       </settings>
 
       <sign-up-panel class="sign-up-panel hidden">
-        <span class="fx-relay-font-met welcome">Welcome</span>
-        <p class="intro">
-          Get started by signing in to Relay with your Firefox account.
-        </p>
-        <a class="button sign-in-btn blue-primary-btn close-popup-after-click login-link" data-event-action="click" data-event-label="panel-continue-btn" href="">
-          Continue
-        </a>
+        <span class="fx-relay-font-met welcome i18n-content" data-i18n-message-id="popupSignUpPanelWelcome"></span>
+        <p class="intro i18n-content" data-i18n-message-id="popupSignUpPanelIntro"></p>
+        <a class="button sign-in-btn blue-primary-btn close-popup-after-click login-link i18n-content" data-event-action="click" data-event-label="panel-continue-btn" data-i18n-message-id="popupSignUpPanelContinue" href=""></a>
       </sign-up-panel>
 
       <main-panel class="signed-in-panel hidden">
@@ -58,16 +55,16 @@
           <p class="onboarding-p"></p>
 
           <div class="onboarding-pagination">
-            <button class="panel-nav previous-panel" data-direction="-1" aria-label="Show previous panel"></button>
+            <button class="panel-nav previous-panel i18n-attribute" data-direction="-1" data-i18n-attribute="aria-label" data-i18n-message-id="popupOnboardingShowPrevious" aria-label=""></button>
             <span class="panel-num fx-relay-font-met">
               <span class="current-panel"></span>/
                 <span class="total-panels">3</span>
             </span>
-            <button class="panel-nav next-panel" data-direction="1" aria-label="Go to next panel"></button>
+            <button class="panel-nav next-panel i18n-attribute" data-direction="1" data-i18n-attribute="aria-label" data-i18n-message-id="popupOnboardingShowNext" aria-label=""></button>
           </div>
         </onboarding-panel>
         <footer>
-          <a class="button fx-relay-new-tab close-popup-after-click footer-button dashboard-link" href="" data-event-action="click" data-event-label="panel-manage-all-aliases-btn">Manage All Aliases</a>
+          <a class="button fx-relay-new-tab close-popup-after-click footer-button dashboard-link i18n-content" href="" data-event-action="click" data-event-label="panel-manage-all-aliases-btn" data-i18n-message-id="popupOnboardingManageAll"></a>
         </footer>
       </main-panel>
     </panel-content>

--- a/src/popup.html
+++ b/src/popup.html
@@ -64,7 +64,7 @@
           </div>
         </onboarding-panel>
         <footer>
-          <a class="button fx-relay-new-tab close-popup-after-click footer-button dashboard-link i18n-content" href="" data-event-action="click" data-event-label="panel-manage-all-aliases-btn" data-i18n-message-id="popupOnboardingManageAll"></a>
+          <a class="button fx-relay-new-tab close-popup-after-click footer-button dashboard-link i18n-content" href="" data-event-action="click" data-event-label="panel-manage-all-aliases-btn" data-i18n-message-id="ManageAllAliases"></a>
         </footer>
       </main-panel>
     </panel-content>

--- a/src/popup.html
+++ b/src/popup.html
@@ -48,7 +48,7 @@
       </sign-up-panel>
 
       <main-panel class="signed-in-panel hidden">
-        <p class="fx-relay-font-met aliases-remaining remaining-plural">You have <span class="num-aliases-remaining"></span><span class="fx-relay-font-met max-num-aliases"></span> remaining aliases</p>
+        <p class="fx-relay-font-met aliases-remaining remaining-plural"></p>
         <onboarding-panel>
           <img class="onboarding-img">
           <h1 class="onboarding-h1"></h1>


### PR DESCRIPTION
To test ...

1. Download [German Firefox Nightly](https://www.mozilla.org/en-US/firefox/all/?q=German,%20Deutsch#product-desktop-nightly)
2. Run German Firefox (from its .dmg so you don't over-write your English Nightly)
3. Go to `about:debugging`
4. Click "Dieser Nightly"
5. Click "Temporares Add-on laden..."
6. Navigate to this branch's `manifest.json`

Expected results:
The first-run.html page should display in (Google-translated) German!

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/71928/123164827-0fe7b580-d439-11eb-99d4-d164a8de00e4.png">
