### PR TITLE
Premium create unlimited aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fx-private-relay-add-on",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Firefox Relay",
   "main": "index.js",
   "dependencies": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -60,6 +60,15 @@
             }
         }
     },
+    "popupUnlimitedAliases": {
+        "message": "You have created $COUNT$ aliases",
+        "description": "Tells the aliases these premium user has created.",
+        "placeholders": {
+            "count": {
+                "content": "$1"
+            }
+        }
+    },
     "popupOnboardingShowPrevious": {
         "message": "Show previous panel"
     },

--- a/src/js/add_input_icon.js
+++ b/src/js/add_input_icon.js
@@ -209,14 +209,22 @@ async function addRelayIconToInput(emailInput) {
     const { maxNumAliases } = await browser.storage.local.get("maxNumAliases");
 
     const numAliasesRemaining = maxNumAliases - relayAddresses.length;
-    const aliases = (numAliasesRemaining === 1) ? "alias" : "aliases";
+
+    // Free user: Set text informing them how many aliases they can create
     remainingAliasesSpan.textContent = browser.i18n.getMessage("popupRemainingAliases", [numAliasesRemaining, maxNumAliases]);
 
+    // Free user (who once was premium): Set text informing them how they have exceeded the maximum amount of aliases and cannot create any more
+    if (numAliasesRemaining < 0) {
+      console.log("too many for free");
+      remainingAliasesSpan.textContent = browser.i18n.getMessage("pageFillRelayAddressLimit");
+    }
+    
+    // Premium user: Set text informing them how many aliases they have created so far
     if (premium) {
       remainingAliasesSpan.textContent = browser.i18n.getMessage("popupUnlimitedAliases", [relayAddresses.length]);
     }
 
-    const maxNumAliasesReached = numAliasesRemaining === 0;
+    const maxNumAliasesReached = (numAliasesRemaining <= 0);
 
     if (maxNumAliasesReached && !premium) {
       generateAliasBtn.disabled = true;
@@ -267,7 +275,7 @@ async function addRelayIconToInput(emailInput) {
         });
 
         const errorMessage = createElementWithClassList("p", "fx-relay-error-message");
-        errorMessage.textContent = browser.i18n.getMessage("pageInputIconMaxAliasesError");
+        errorMessage.textContent = browser.i18n.getMessage("pageInputIconMaxAliasesError", [relayAddresses.length]);
 
         relayInPageMenu.insertBefore(errorMessage, relayMenuDashboardLink);
         return;

--- a/src/js/add_input_icon.js
+++ b/src/js/add_input_icon.js
@@ -200,6 +200,8 @@ async function addRelayIconToInput(emailInput) {
     generateAliasBtn.textContent = browser.i18n.getMessage("pageInputIconGenerateNewAlias");
 
 
+    // If the user has a premium accout, they may create unlimited aliases. 
+    const { premium } = await browser.storage.local.get("premium");
 
     // Create "You have .../.. remaining relay address" message
     const remainingAliasesSpan = createElementWithClassList("span", "fx-relay-menu-remaining-aliases");
@@ -210,8 +212,13 @@ async function addRelayIconToInput(emailInput) {
     const aliases = (numAliasesRemaining === 1) ? "alias" : "aliases";
     remainingAliasesSpan.textContent = browser.i18n.getMessage("popupRemainingAliases", [numAliasesRemaining, maxNumAliases]);
 
+    if (premium) {
+      remainingAliasesSpan.textContent = browser.i18n.getMessage("popupUnlimitedAliases", [relayAddresses.length]);
+    }
+
     const maxNumAliasesReached = numAliasesRemaining === 0;
-    if (maxNumAliasesReached) {
+
+    if (maxNumAliasesReached && !premium) {
       generateAliasBtn.disabled = true;
       sendInPageEvent("viewed-menu", "input-menu-max-aliases-message")
     }

--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -8,8 +8,11 @@
   const addonStorageRelayAddresses = await browser.storage.local.get("relayAddresses");
   const addonRelayAddresses = (Object.keys(addonStorageRelayAddresses).length === 0) ? {relayAddresses: []} : addonStorageRelayAddresses;
 
-  // Loop over the addresses on the page
+  // Check if user is premium
+  const isPremiumUser = document.querySelector("body").classList.contains("is-premium");
+  browser.storage.local.set({"premium": isPremiumUser});
 
+  // Loop over the addresses on the page    
   const dashboardRelayAliasCards = document.querySelectorAll("[data-relay-address]");
   const relayAddresses = [];
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Firefox Relay",
-  "version": "1.5.1",
+  "version": "1.6.0",
 
   "description": "__MSG_extensionDescription__",
 


### PR DESCRIPTION
This PR detects if a authenticated user is premium. If so, the max alias count restriction is lifted! 

<img width="359" alt="image" src="https://user-images.githubusercontent.com/2692333/129251803-0bde2531-54fe-4ab8-9aa5-53c68f383577.png">


## Testing

Premium user: 
- Run add-on, log into site as a premium user
- Have more than 5 aliases created on your account
- **Expected:** On email login, badge should allow you to create additional aliases. The text should read "You have created `X` aliases"

Free user: 
- Run add-on, log into site as a premium user
- Have more than 5 aliases created on your account
- **Expected:** On email login, badge should allow you to create additional aliases. The text should read "You have created `X` aliases"

## Edge cases: 

If for some reason the user sets their add-on to "premium", when they aren't – they will get the following message: 

<img width="344" alt="image" src="https://user-images.githubusercontent.com/2692333/129250743-c30507f4-73b0-433b-ae4d-029a2fb92c67.png">

If a user has created more than the max aliases and downgraded their account, the following happens: 
<img width="332" alt="image" src="https://user-images.githubusercontent.com/2692333/129251698-58c536b5-8582-41c0-b195-d85874833251.png">
