### PR TITLE
[OLD] Fix #118 - Only show premium UI if premium is enabled

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -458,8 +458,8 @@ onboarding-panel {
   align-items: right;
 }
 
-.email-domain-illustration {
-  margin: 0 auto;
+.register-domain-illustration {
+  margin: 16px auto;
   display: block;
   width: 280px;
 }

--- a/src/js/data-opt-out-toggle.js
+++ b/src/js/data-opt-out-toggle.js
@@ -13,7 +13,7 @@ async function enableDataOptOut() {
       return;
     }
     dataCollectionPrefToggle.classList.add("data-disabled");
-    dataCollectionPrefToggle.title = "Allow data collection";
+    dataCollectionPrefToggle.title = browser.i18n.getMessage("allowDataCollection");
     dataCollectionPrefToggle.dataset.collectionPreference = "data-enabled";
   };
 

--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -16,16 +16,25 @@
   const dashboardRelayAliasCards = document.querySelectorAll("[data-relay-address]");
   const relayAddresses = [];
 
-   //Get FXA dashboard data from profile
-   const {aliasesUsedVal, emailsForwardedVal, emailsBlockedVal} = document.querySelector("firefox-private-relay-addon-dashboard-data").dataset;
-   browser.storage.local.set({aliasesUsedVal, emailsForwardedVal, emailsBlockedVal});
-   
    // Get FXA Stuff
    const fxaSubscriptionsUrl = document.querySelector("firefox-private-relay-addon-data").dataset.fxaSubscriptionsUrl;
    const premiumProdId = document.querySelector("firefox-private-relay-addon-data").dataset.premiumProdId;
    const premiumPriceId = document.querySelector("firefox-private-relay-addon-data").dataset.premiumPriceId;
+   const aliasesUsedVal = document.querySelector("firefox-private-relay-addon-data").dataset.aliasesUsedVal;
+   const emailsForwardedVal = document.querySelector("firefox-private-relay-addon-data").dataset.emailsForwardedVal;
+   const emailsBlockedVal = document.querySelector("firefox-private-relay-addon-data").dataset.emailsBlockedVal;
    const premiumSubdomainSet = document.querySelector("firefox-private-relay-addon-data").dataset.premiumSubdomainSet;
-   browser.storage.local.set({fxaSubscriptionsUrl, premiumProdId, premiumPriceId, premiumSubdomainSet});
+   const premiumEnabled = document.querySelector("firefox-private-relay-addon-data").dataset.premiumEnabled;
+   browser.storage.local.set({
+    fxaSubscriptionsUrl,
+    premiumProdId,
+    premiumPriceId,
+    aliasesUsedVal,
+    emailsForwardedVal,
+    emailsBlockedVal,
+    premiumSubdomainSet,
+    premiumEnabled
+   });
 
   for (const aliasCard of dashboardRelayAliasCards) {
     // Add the domain note from the addon storage to the page

--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -43,7 +43,7 @@
     const aliasId = aliasCardData.relayAddressId;
     const addonRelayAddress = addonRelayAddresses.relayAddresses.filter(address => address.id == aliasId)[0];
 
-    const defaultAliasLabelText = "Add account name";
+    const defaultAliasLabelText = browser.i18n.getMessage("profilePageDefaulAliasLabelText");
     const storedAliasLabel = (addonRelayAddress && addonRelayAddress.hasOwnProperty("domain")) ? addonRelayAddress.domain : "";
 
     const aliasLabelInput = aliasCard.querySelector("input.relay-email-address-label");

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -51,11 +51,12 @@ function showSignUpPanel() {
 }
 
 
-function choosePanel(numRemaining, panelId, premium){
-  if (premium){
+function choosePanel(numRemaining, panelId, premium, premiumEnabledString){
+  if (premium && premiumEnabledString === "True") {
     document.getElementsByClassName("content-wrapper")[0].remove();
     return 'premiumPanel';
   }
+
   else {
     const premiumWrapper = document.getElementsByClassName("premium-wrapper")
     if (premiumWrapper.length) {
@@ -66,11 +67,15 @@ function choosePanel(numRemaining, panelId, premium){
 }
 
 function checkUserSubdomain(premiumSubdomainSet){
-  if(premiumSubdomainSet != "None"){
-    document.getElementsByClassName("register-domain-component")[0].remove();
+  const educationalComponent = document.querySelector(".educational-component");
+  const registerDomainComponent = document.querySelector(".register-domain-component");
+
+  if (premiumSubdomainSet != "None") {
+    registerDomainComponent.classList.add("is-hidden");
   }
+
   else {
-    document.getElementsByClassName("educational-component")[0].remove();
+    educationalComponent.classList.add("is-hidden");
   }
 }
 
@@ -87,16 +92,20 @@ async function showRelayPanel(tipPanelToShow) {
 
   //Premium Panel
   const premiumPanelWrapper = document.querySelector(".premium-wrapper");
-  const registerDomainImgEl = premiumPanelWrapper.querySelector(".email-domain-illustration");
-
+  const registerDomainImgEl = premiumPanelWrapper.querySelector(".register-domain-illustration");
   const aliasesUsedValEl = premiumPanelWrapper.querySelector(".aliases-used");
   const emailsBlockedValEl = premiumPanelWrapper.querySelector(".emails-blocked");
   const emailsForwardedValEl = premiumPanelWrapper.querySelector(".emails-forwarded");
 
+  //Setting premium logic
+  const premiumEnabled = await browser.storage.local.get("premiumEnabled");
+  const premiumEnabledString = premiumEnabled.premiumEnabled;
+  const premiumSubdomainSet = await browser.storage.local.get("premiumSubdomainSet");
+  const premiumSubdomainSetString = premiumSubdomainSet.premiumSubdomainSet;
   const { premium } = await browser.storage.local.get("premium");
 
   const updatePanel = (numRemaining, panelId) => {
-    const panelToShow = choosePanel(numRemaining, panelId, premium);
+    const panelToShow = choosePanel(numRemaining, panelId, premium, premiumEnabledString);
     onboardingPanelWrapper.classList = [panelToShow];
     const panelStrings = onboardingPanelStrings[`${panelToShow}`];
 
@@ -113,12 +122,20 @@ async function showRelayPanel(tipPanelToShow) {
     emailsBlockedValEl.textContent = emailsBlockedVal;
     emailsForwardedValEl.textContent = emailsForwardedVal;
 
+    //Show premium panel state
+    if (premium && premiumEnabledString === "True"){
+      premiumPanelWrapper.classList.remove("is-hidden");
+      premiumPanelWrapper.querySelectorAll(".is-hidden").forEach(premiumFeature => 
+        premiumFeature.classList.remove("is-hidden") 
+      );
+      //Toggle register domain or education module
+      checkUserSubdomain(premiumSubdomainSetString);
+    }
+
     return;
   };
 
   //Educational Matrix
-  const premiumSubdomainSet = await browser.storage.local.get("premiumSubdomainSet");
-  checkUserSubdomain(premiumSubdomainSet);
   const educationalImgEl = premiumPanelWrapper.querySelector(".education-img");
   const educationalModuleToShow = educationalStrings["educationalComponent1"];
   const educationalComponentStrings = educationalModuleToShow;
@@ -159,6 +176,7 @@ async function showRelayPanel(tipPanelToShow) {
   }
   return sendRelayEvent("Panel","viewed-panel", "authenticated-user-panel");
 }
+
 
 async function getDashboardData() {
   const { aliasesUsedVal, emailsForwardedVal, emailsBlockedVal } = await browser.storage.local.get();
@@ -256,7 +274,7 @@ async function popup() {
   const { fxaSubscriptionsUrl } = await browser.storage.local.get("fxaSubscriptionsUrl");
   const { premiumProdId } = await browser.storage.local.get("premiumProdId");
   const { premiumPriceId } = await browser.storage.local.get("premiumPriceId");
-
+  const { premium } = await browser.storage.local.get("premium");
 
   document.querySelectorAll(".login-link").forEach(loginLink => {
     loginLink.href = `${relaySiteOrigin}/accounts/profile?utm_source=fx-relay-addon&utm_medium=popup&utm_content=popup-continue-btn`;
@@ -275,8 +293,7 @@ async function popup() {
     registerDomainLink.href = `${relaySiteOrigin}/accounts/profile`;
   });
 
-  const { premium } = await browser.storage.local.get("premium");
-
+  //Remove status bar when user is premium
   if (!premium) {  
     const panelStatus = document.querySelector(".panel-status");
     panelStatus.classList.remove("is-hidden");

--- a/src/popup.html
+++ b/src/popup.html
@@ -77,8 +77,9 @@
             </div>
           </div>
           <!-- Premium Panel-->
-          <div class="premium-wrapper">
-            <div class="premium-dashboard">
+          <div class="premium-wrapper is-hidden">
+            <!-- Premium Dashboard-->
+            <div class="premium-dashboard is-hidden">
               <ul>
                 <li class="dashboard-info">
                   <span class="aliases-used-text i18n-content" data-i18n-message-id="popupAliasesUsed"></span>
@@ -94,12 +95,14 @@
                 </li>
               </ul>
             </div>
-            <div class="register-domain-component">
+            <!--Register Domain Module-->
+            <div class="register-domain-component is-hidden">
+              <img class="register-domain-illustration">
               <p class="register-domain-headline i18n-content" data-i18n-message-id="popupRegisterDomainHeadline"></p>
-              <img class="email-domain-illustration">
               <a class="register-domain-cta i18n-content button sign-in-btn blue-primary-btn close-popup-after-click" data-event-action="click" data-i18n-message-id="popupRegisterDomainButton"></a> 
             </div>
-            <div class="educational-component">
+            <!--Education Matrix Module-->
+            <div class="educational-component is-hidden">
               <img class="education-img">
               <div class="education-description">
                 <h1 class="education-headline i18n-content" data-i18n-message-id="popupEducationalComponent1Headline"></h1>

--- a/src/popup.html
+++ b/src/popup.html
@@ -53,7 +53,7 @@
           <a 
             class="premium-cta i18n-content close-popup-after-click button get-premium-link" 
             data-event-action="click"
-            data-i18n-message-id="popupGetUnlimitedAliases"
+            data-i18n-message-id="popupGetUnlimitedAliases-2"
             >
           </a>
       </span>


### PR DESCRIPTION
This PR:
- Takes into account the value of `settings.PREMIUM_ENABLED`, which checks whether premium features are available on the site. 
-  So if the aforementioned value doesn't return `True`, the add on defaults back to a 'non-premium' view.

- All premium UI blocks now have a `is-hidden` utility class.