### PR TITLE
Fix panel bar l10n strings

### DIFF
--- a/src/js/add_input_icon.js
+++ b/src/js/add_input_icon.js
@@ -211,7 +211,7 @@ async function addRelayIconToInput(emailInput) {
     const numAliasesRemaining = maxNumAliases - relayAddresses.length;
 
     // Free user: Set text informing them how many aliases they can create
-    remainingAliasesSpan.textContent = browser.i18n.getMessage("popupRemainingAliases", [numAliasesRemaining, maxNumAliases]);
+    remainingAliasesSpan.textContent = browser.i18n.getMessage("popupRemainingAliases-2", [numAliasesRemaining, maxNumAliases]);
 
     // Free user (who once was premium): Set text informing them how they have exceeded the maximum amount of aliases and cannot create any more
     if (numAliasesRemaining < 0) {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -130,10 +130,14 @@ async function showRelayPanel(tipPanelToShow) {
   const { emailsForwardedVal } = await browser.storage.local.get("emailsForwardedVal");
   const { emailsBlockedVal } = await browser.storage.local.get("emailsBlockedVal");
 
+
+  //Nonpremium panel status 
   const { relayAddresses, maxNumAliases } = await getRemainingAliases();
   const numRemaining = maxNumAliases - relayAddresses.length;
   const remainingAliasMessage = document.querySelector(".aliases-remaining");
-  remainingAliasMessage.textContent = browser.i18n.getMessage("popupRemainingAliases", [numRemaining, maxNumAliases]);
+  remainingAliasMessage.textContent = browser.i18n.getMessage("popupRemainingAliases-2", [numRemaining, maxNumAliases]);
+  const getUnlimitedAliases = document.querySelector(".premium-cta");
+  getUnlimitedAliases.textContent = browser.i18n.getMessage("popupGetUnlimitedAliases", [numRemaining, maxNumAliases]);
 
   document.body.classList.add("relay-panel");
   updatePanel(numRemaining, tipPanelToShow);

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -137,7 +137,7 @@ async function showRelayPanel(tipPanelToShow) {
   const remainingAliasMessage = document.querySelector(".aliases-remaining");
   remainingAliasMessage.textContent = browser.i18n.getMessage("popupRemainingAliases-2", [numRemaining, maxNumAliases]);
   const getUnlimitedAliases = document.querySelector(".premium-cta");
-  getUnlimitedAliases.textContent = browser.i18n.getMessage("popupGetUnlimitedAliases", [numRemaining, maxNumAliases]);
+  getUnlimitedAliases.textContent = browser.i18n.getMessage("popupGetUnlimitedAliases");
 
   document.body.classList.add("relay-panel");
   updatePanel(numRemaining, tipPanelToShow);

--- a/src/popup.html
+++ b/src/popup.html
@@ -53,7 +53,7 @@
           <a 
             class="premium-cta i18n-content close-popup-after-click button get-premium-link" 
             data-event-action="click"
-            data-i18n-message-id="popupGetUnlimitedAliases-2"
+            data-i18n-message-id="popupGetUnlimitedAliases"
             >
           </a>
       </span>


### PR DESCRIPTION
Some of the l10n strings for the panel bar on non premium view were mis-IDed. Should work now: [demo](https://drive.google.com/file/d/1E6M4JuAuCajdPDOi2DNxRJXmPEu_9Q18/view?usp=sharing)
