### PR TITLE
Add Get Unlimited Aliases CTA on Field Input Popup and Context Menu

### DIFF
--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -199,15 +199,13 @@ button.fx-relay-modal-close-button {
   flex-direction: column;
   position: absolute;
   align-content: center;
-  padding-top: 20px;
-  padding-left: 0;
-  padding-right: 0;
-  padding-bottom: 0;
+  padding: 24px 16px 16px 16px;
   top: 47px;
   right: -15px;
   pointer-events: all;
   animation: fxRelayFadeIn 0.2s ease forwards;
   box-shadow: 3px 3px 3px 3px #00000017;
+  box-sizing: border-box;
 }
 
 .fx-relay-menu::before {
@@ -242,74 +240,82 @@ button.fx-relay-modal-close-button {
 
 .fx-relay-menu-remaining-aliases {
   font-size: 14px;
-  width: 260px;
-  padding: 12px 0;
+  width: 100%;
+  padding: 16px 0px;
   background: var(--relayGrey20);
   color: var(--relayGrey60);
   text-align: center;
-  font-weight: 600;
-  font-size: 14px;
   border-radius: 4px;
-  margin: auto auto 12px auto;
+  margin-bottom: 8px;
+  font-weight: 600;
 }
 
-button.fx-relay-menu-sign-up-btn,
-.fx-relay-menu-dashboard-link {
+button.fx-relay-menu-sign-up-btn{
   font-size: 15px;
   border: 1px solid rgba(0, 0, 0, 0);
   border-color: rgba(0, 0, 0, 0);
   outline: none;
   width: 100%;
   min-width: 100%;
-  font-family: var(--relayMetropolis) !important;
-  color: var(--relayInk) !important;
+  font-family: var(--relayMetropolis);
+  color: var(--relayInk);
   display: flex;
   min-height: auto;
   box-shadow: none;
   box-sizing: border-box;
-  background-color: var(--relayGrey20) !important;
+  background-color: var(--relayGrey20);
   text-align: center;
   justify-content: center;
   padding: 12px 24px;
   pointer-events: all;
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
-  text-decoration: none !important;
+  text-decoration: none;
 }
 
 .fx-relay-menu-dashboard-link {
-  margin: auto auto 0 auto;
+  color: var(--relayBlue3);
+  font-size: 15px;
+  font-family: "InterUI", sans-serif;
+  text-align: center;
+  padding: 8px;
+  margin: 16px 0 0 0;
+  border-radius: 4px;
+}
+
+.fx-relay-menu-dashboard-link:hover {
+  background: var(--relayGrey20);
+  text-decoration: none;
+  color: var(--relayBlue3);
 }
 
 button.fx-relay-menu-generate-alias-btn {
   background-color: var(--relayBlue3) !important;
-  padding: 12px !important;
-  width: 260px !important;
+  width: 100%;
+  padding: 16px 0px;
   border-radius: 4px !important;
   font-family: var(--relayMetropolis) !important;
   color: rgba(255, 255, 255, 1) !important;
   border: none !important;
   font-size: 16px !important;
-  margin: auto auto 16px auto !important;
   text-align: center !important;
-  font-weight: 500 !important;
+  margin-top: 4px;
 }
 
 .fx-relay-menu-get-unlimited-aliases {
-  border: 2px solid var(--relayBlue3) !important;
-  padding: 12px !important;
-  width: 240px !important;
-  border-radius: 4px !important;
-  font-family: var(--InterUI) !important;
-  color: var(--relayBlue3) !important;
-  font-size: 16px !important;
-  text-align: center !important;
-  font-weight: 500 !important;
-  margin: auto auto 16px auto !important;
+  border: 2px solid var(--relayBlue3);
+  width: 100%;
+  padding: 16px 0px;
+  border-radius: 4px;
+  font-family: "InterUI", sans-serif;
+  color: var(--relayBlue3);
+  font-size: 16px;
+  text-align: center;
 }
 
 .fx-relay-menu-get-unlimited-aliases:hover {
   text-decoration: none;
+  color: white;
   background-color: var(--relayBlueHover) !important;
 }
 
@@ -328,7 +334,6 @@ button.fx-relay-menu-generate-alias-btn[disabled] {
 }
 
 .fx-relay-menu-sign-up-btn:hover,
-.fx-relay-menu-dashboard-link:hover,
 .fx-relay-modal-close-button:hover {
   background-color: var(--relayGrey30) !important;
 }

--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -247,7 +247,16 @@ button.fx-relay-modal-close-button {
   text-align: center;
   margin-top: 8px;
   margin-bottom: 24px;
-  font-weight: 600 !important;
+  font-weight: 600;
+}
+
+.max-num-aliases {
+  background: var(--relayGrey30);
+  color: var(--relayGrey60);
+  padding: 16px;
+  font-size: 14px;
+  border-radius: 4px;
+  margin: 12px 16px;
 }
 
 button.fx-relay-menu-sign-up-btn,
@@ -293,13 +302,12 @@ button.fx-relay-menu-generate-alias-btn {
 }
 
 .fx-relay-menu-get-unlimited-aliases {
-  background-color: var(--relayBlue3) !important;
+  border: 2px solid var(--relayBlue3) !important;
   padding: 12px !important;
-  width: 260px !important;
+  width: 240px !important;
   border-radius: 4px !important;
-  font-family: var(--relayMetropolis) !important;
-  color: rgba(255, 255, 255, 1) !important;
-  border: none !important;
+  font-family: var(--InterUI) !important;
+  color: var(--relayBlue3) !important;
   font-size: 16px !important;
   margin: auto !important;
   text-align: center !important;

--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -289,7 +289,7 @@ button.fx-relay-menu-generate-alias-btn {
 
 .fx-relay-menu-get-unlimited-aliases:hover {
   text-decoration: none;
-  color: white;
+  color: white !important;
   background-color: var(--relayBlueHover) !important;
 }
 

--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -242,21 +242,15 @@ button.fx-relay-modal-close-button {
 
 .fx-relay-menu-remaining-aliases {
   font-size: 14px;
-  padding: 0 24px;
-  color: var(--relayInk70);
-  text-align: center;
-  margin-top: 8px;
-  margin-bottom: 24px;
-  font-weight: 600;
-}
-
-.max-num-aliases {
-  background: var(--relayGrey30);
+  width: 260px;
+  padding: 12px 0;
+  background: var(--relayGrey20);
   color: var(--relayGrey60);
-  padding: 16px;
+  text-align: center;
+  font-weight: 600;
   font-size: 14px;
   border-radius: 4px;
-  margin: 12px 16px;
+  margin: auto auto 12px auto;
 }
 
 button.fx-relay-menu-sign-up-btn,
@@ -296,7 +290,7 @@ button.fx-relay-menu-generate-alias-btn {
   color: rgba(255, 255, 255, 1) !important;
   border: none !important;
   font-size: 16px !important;
-  margin: auto !important;
+  margin: auto auto 16px auto !important;
   text-align: center !important;
   font-weight: 500 !important;
 }
@@ -309,9 +303,9 @@ button.fx-relay-menu-generate-alias-btn {
   font-family: var(--InterUI) !important;
   color: var(--relayBlue3) !important;
   font-size: 16px !important;
-  margin: auto !important;
   text-align: center !important;
   font-weight: 500 !important;
+  margin: auto auto 16px auto !important;
 }
 
 .fx-relay-menu-get-unlimited-aliases:hover {

--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -341,7 +341,8 @@ button.fx-relay-menu-generate-alias-btn[disabled] {
 .fx-relay-menu-dashboard-link:focus,
 .fx-relay-menu button.fx-relay-menu-generate-alias-btn:focus,
 .fx-relay-menu-sign-up-btn:focus,
-.fx-relay-modal-close-button:focus {
+.fx-relay-modal-close-button:focus,
+.fx-relay-menu-get-unlimited-aliases:focus {
   box-shadow: var(--relayButtonFocus) !important;
 }
 

--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -280,20 +280,35 @@ button.fx-relay-menu-sign-up-btn,
 
 button.fx-relay-menu-generate-alias-btn {
   background-color: var(--relayBlue3) !important;
-  padding-top: 12px !important;
-  padding-bottom: 12px !important;
-  padding-left: 28px !important;
-  padding-right: 28px !important;
-  max-width: 260px;
-  width: 100%;
+  padding: 12px !important;
+  width: 260px !important;
+  border-radius: 4px !important;
   font-family: var(--relayMetropolis) !important;
   color: rgba(255, 255, 255, 1) !important;
   border: none !important;
-  border-radius: 2px !important;
   font-size: 16px !important;
   margin: auto !important;
   text-align: center !important;
   font-weight: 500 !important;
+}
+
+.fx-relay-menu-get-unlimited-aliases {
+  background-color: var(--relayBlue3) !important;
+  padding: 12px !important;
+  width: 260px !important;
+  border-radius: 4px !important;
+  font-family: var(--relayMetropolis) !important;
+  color: rgba(255, 255, 255, 1) !important;
+  border: none !important;
+  font-size: 16px !important;
+  margin: auto !important;
+  text-align: center !important;
+  font-weight: 500 !important;
+}
+
+.fx-relay-menu-get-unlimited-aliases:hover {
+  text-decoration: none;
+  background-color: var(--relayBlueHover) !important;
 }
 
 button.fx-relay-menu-generate-alias-btn[disabled] {

--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -74,12 +74,10 @@
 }
 
 .fx-relay-modal-content fx-relay-logo-wrapper {
-  border-bottom: 1px solid rgba(0, 0, 0, 0) !important;
   justify-content: flex-start;
   display: flex;
   width: 100%;
-  margin: 1rem auto 2rem 1rem;
-
+  padding-bottom: 1em;
 }
 
 fx-relay-logotype {
@@ -111,19 +109,6 @@ fx-relay-logomark {
   font-size: 16px;
 }
 
-.fx-relay-modal-manage-aliases {
-  margin-top: 2rem;
-  height: 48px;
-  border-top: 1px solid #eee;
-  width: 100% !important;
-  text-align: center !important;
-  display: flex !important;
-  justify-content: center !important;
-  align-content: center !important;
-  align-items: center !important;
-  text-decoration: none !important;
-}
-
 fx-relay-logotype,
 fx-relay-logomark {
   background-repeat: no-repeat;
@@ -150,11 +135,10 @@ fx-relay-logomark {
 }
 
 .fx-relay-modal-content {
-  max-width: 500px;
-  min-width: 400px;
+  width: 300px;
+  padding: 24px 16px 16px 16px;
   background-color: rgba(255, 255, 255, 1);
   border-radius: 8px;
-  padding: 0;
   box-shadow: 0 7px 12px -3px rgba(28, 28, 29, 0.502);
   display: flex;
   flex-direction: column;
@@ -163,16 +147,6 @@ fx-relay-logomark {
   justify-content: center;
   position: relative;
   overflow: hidden;
-}
-
-.fx-relay-modal-message {
-  font-size: 18px !important;
-  max-width: 250px;
-  line-height: 1.5;
-  text-align: center;
-  color: #2b1e44d6;
-  margin-bottom: 1rem;
-  font-family: var(--InterUI);
 }
 
 button.fx-relay-modal-close-button {
@@ -238,7 +212,7 @@ button.fx-relay-modal-close-button {
   animation: fxRelayFadeIn 1s ease;
 }
 
-.fx-relay-menu-remaining-aliases {
+.fx-relay-menu-remaining-aliases, .fx-relay-modal-message {
   font-size: 14px;
   width: 100%;
   padding: 16px 0px;
@@ -273,8 +247,8 @@ button.fx-relay-menu-sign-up-btn{
   text-decoration: none;
 }
 
-.fx-relay-menu-dashboard-link {
-  color: var(--relayBlue3);
+.fx-relay-menu-dashboard-link, .fx-relay-modal-manage-aliases {
+  color: var(--relayBlue3) !important;
   font-size: 15px;
   font-family: "InterUI", sans-serif;
   text-align: center;
@@ -283,7 +257,7 @@ button.fx-relay-menu-sign-up-btn{
   border-radius: 4px;
 }
 
-.fx-relay-menu-dashboard-link:hover {
+.fx-relay-menu-dashboard-link:hover, .fx-relay-modal-manage-aliases:hover {
   background: var(--relayGrey20);
   text-decoration: none;
   color: var(--relayBlue3);
@@ -308,7 +282,7 @@ button.fx-relay-menu-generate-alias-btn {
   padding: 16px 0px;
   border-radius: 4px;
   font-family: "InterUI", sans-serif;
-  color: var(--relayBlue3);
+  color: var(--relayBlue3) !important;
   font-size: 16px;
   text-align: center;
 }
@@ -358,6 +332,7 @@ button.fx-relay-menu-generate-alias-btn[disabled] {
   display: inline-block;
   line-height: 1.3;
   margin: auto auto 24px auto;
+  color: black;
 }
 
 .fx-relay-icon {

--- a/src/js/add_input_icon.js
+++ b/src/js/add_input_icon.js
@@ -227,6 +227,8 @@ async function addRelayIconToInput(emailInput) {
     // Create "Get unlimited aliases" button
     const getUnlimitedAliasesBtn = createElementWithClassList("a", "fx-relay-menu-get-unlimited-aliases");
     getUnlimitedAliasesBtn.textContent = browser.i18n.getMessage("popupGetUnlimitedAliases");
+    getUnlimitedAliasesBtn.setAttribute("target", "_blank");
+    getUnlimitedAliasesBtn.setAttribute("rel", "noopener noreferrer");
 
     // If the user has a premium accout, they may create unlimited aliases. 
     const { premium } = await browser.storage.local.get("premium");
@@ -276,10 +278,6 @@ async function addRelayIconToInput(emailInput) {
     [remainingAliasesSpan, getUnlimitedAliasesBtn, generateAliasBtn, relayMenuDashboardLink].forEach(el => {
       relayInPageMenu.appendChild(el);
     });
-
-    //Check if premium features are available
-    const premiumEnabled = await browser.storage.local.get("premiumEnabled");
-    const premiumEnabledString = premiumEnabled.premiumEnabled;
   
     if (!premium) {
       if (maxNumAliasesReached) {
@@ -291,6 +289,10 @@ async function addRelayIconToInput(emailInput) {
     else {
       getUnlimitedAliasesBtn.remove();
     }
+
+    //Check if premium features are available
+    const premiumEnabled = await browser.storage.local.get("premiumEnabled");
+    const premiumEnabledString = premiumEnabled.premiumEnabled;
 
     if(!premiumFeaturesAvailable(premiumEnabledString) || !maxNumAliasesReached){
       getUnlimitedAliasesBtn.remove();

--- a/src/js/add_input_icon.js
+++ b/src/js/add_input_icon.js
@@ -272,6 +272,7 @@ async function addRelayIconToInput(emailInput) {
     //Show get unlimited aliases btn
     if (!premium) {
       if (maxNumAliasesReached) {
+        remainingAliasesSpan.classList.add("max-num-aliases");
         generateAliasBtn.remove();
         sendInPageEvent("viewed-menu", "input-menu-max-aliases-message")
       }
@@ -280,6 +281,11 @@ async function addRelayIconToInput(emailInput) {
         getUnlimitedAliasesBtn.remove();
       }
     }
+
+    else {
+      getUnlimitedAliasesBtn.remove();
+    }
+
 
     // Handle "Generate New Alias" clicks
     generateAliasBtn.addEventListener("click", async(generateClickEvt) => {

--- a/src/js/add_input_icon.js
+++ b/src/js/add_input_icon.js
@@ -117,6 +117,14 @@ function addPaddingRight(element, paddingInPixels) {
   }
 }
 
+function premiumFeaturesAvailable(premiumEnabledString) {
+  if (premiumEnabledString === "True") {
+    return true;
+  }
+  return false;
+}
+
+
 async function addRelayIconToInput(emailInput) {
   const { relaySiteOrigin } = await browser.storage.local.get("relaySiteOrigin");
   // remember the input's original parent element;
@@ -270,26 +278,16 @@ async function addRelayIconToInput(emailInput) {
     });
 
     //Show get unlimited aliases btn
-    if (!premium) {
-      if (maxNumAliasesReached) {
-        generateAliasBtn.remove();
-        sendInPageEvent("viewed-menu", "input-menu-max-aliases-message");
-        remainingAliasesSpan.textContent = browser.i18n.getMessage("pageFillRelayAddressLimit", [numAliasesRemaining, maxNumAliases]);
-      }
-
-      else {
-        getUnlimitedAliasesBtn.remove();
-      }
-    }
-
-    else {
-      getUnlimitedAliasesBtn.remove();
+    if (!premium && maxNumAliasesReached) {
+      generateAliasBtn.remove();
+      sendInPageEvent("viewed-menu", "input-menu-max-aliases-message");
+      remainingAliasesSpan.textContent = browser.i18n.getMessage("pageFillRelayAddressLimit", [numAliasesRemaining, maxNumAliases]);
     }
 
     const premiumEnabled = await browser.storage.local.get("premiumEnabled");
     const premiumEnabledString = premiumEnabled.premiumEnabled;
-
-    if(premiumEnabledString != "True") {
+  
+    if(!premiumFeaturesAvailable(premiumEnabledString) || !maxNumAliasesReached){
       getUnlimitedAliasesBtn.remove();
     }
 

--- a/src/js/add_input_icon.js
+++ b/src/js/add_input_icon.js
@@ -277,20 +277,24 @@ async function addRelayIconToInput(emailInput) {
       relayInPageMenu.appendChild(el);
     });
 
-    //Show get unlimited aliases btn
-    if (!premium && maxNumAliasesReached) {
-      generateAliasBtn.remove();
-      sendInPageEvent("viewed-menu", "input-menu-max-aliases-message");
-      remainingAliasesSpan.textContent = browser.i18n.getMessage("pageFillRelayAddressLimit", [numAliasesRemaining, maxNumAliases]);
-    }
-
+    //Check if premium features are available
     const premiumEnabled = await browser.storage.local.get("premiumEnabled");
     const premiumEnabledString = premiumEnabled.premiumEnabled;
   
-    if(!premiumFeaturesAvailable(premiumEnabledString) || !maxNumAliasesReached){
+    if (!premium) {
+      if (maxNumAliasesReached) {
+        generateAliasBtn.remove();
+        sendInPageEvent("viewed-menu", "input-menu-max-aliases-message");
+        remainingAliasesSpan.textContent = browser.i18n.getMessage("pageFillRelayAddressLimit", [numAliasesRemaining, maxNumAliases]);
+      }  
+    }
+    else {
       getUnlimitedAliasesBtn.remove();
     }
 
+    if(!premiumFeaturesAvailable(premiumEnabledString) || !maxNumAliasesReached){
+      getUnlimitedAliasesBtn.remove();
+    }
 
     // Handle "Generate New Alias" clicks
     generateAliasBtn.addEventListener("click", async(generateClickEvt) => {
@@ -346,6 +350,7 @@ function getEmailInputsAndAddIcon(domRoot) {
     }
   }
 }
+
 
 (async function() {
   const inputIconsAreEnabled = await areInputIconsEnabled();

--- a/src/js/add_input_icon.js
+++ b/src/js/add_input_icon.js
@@ -216,6 +216,9 @@ async function addRelayIconToInput(emailInput) {
     const generateAliasBtn = createElementWithClassList("button", "fx-relay-menu-generate-alias-btn");
     generateAliasBtn.textContent = browser.i18n.getMessage("pageInputIconGenerateNewAlias");
 
+    // Create "Get unlimited aliases" button
+    const getUnlimitedAliasesBtn = createElementWithClassList("a", "fx-relay-menu-get-unlimited-aliases");
+    getUnlimitedAliasesBtn.textContent = browser.i18n.getMessage("popupGetUnlimitedAliases");
 
     // If the user has a premium accout, they may create unlimited aliases. 
     const { premium } = await browser.storage.local.get("premium");
@@ -243,11 +246,6 @@ async function addRelayIconToInput(emailInput) {
 
     const maxNumAliasesReached = (numAliasesRemaining <= 0);
 
-    if (maxNumAliasesReached && !premium) {
-      generateAliasBtn.disabled = true;
-      sendInPageEvent("viewed-menu", "input-menu-max-aliases-message")
-    }
-
     // Create "Manage All Aliases" link
     const relayMenuDashboardLink = createElementWithClassList("a", "fx-relay-menu-dashboard-link");
     relayMenuDashboardLink.textContent = browser.i18n.getMessage("ManageAllAliases");
@@ -257,14 +255,31 @@ async function addRelayIconToInput(emailInput) {
       sendInPageEvent("click", "input-menu-manage-all-aliases-btn");
     });
 
+    //Create "Get unlimited aliases" link
+    const { fxaSubscriptionsUrl } = await browser.storage.local.get("fxaSubscriptionsUrl");
+    const { premiumProdId } = await browser.storage.local.get("premiumProdId");
+    const { premiumPriceId } = await browser.storage.local.get("premiumPriceId");
+    getUnlimitedAliasesBtn.href = `${fxaSubscriptionsUrl}/products/${premiumProdId}?plan=${premiumPriceId}`;
+
     // Restrict tabbing to relay menu elements
     restrictOrRestorePageTabbing(-1);
 
     // Append menu elements to the menu
-    [generateAliasBtn, remainingAliasesSpan, relayMenuDashboardLink].forEach(el => {
+    [getUnlimitedAliasesBtn, generateAliasBtn, remainingAliasesSpan, relayMenuDashboardLink].forEach(el => {
       relayInPageMenu.appendChild(el);
     });
 
+    //Show get unlimited aliases btn
+    if (!premium) {
+      if (maxNumAliasesReached) {
+        generateAliasBtn.remove();
+        sendInPageEvent("viewed-menu", "input-menu-max-aliases-message")
+      }
+
+      else {
+        getUnlimitedAliasesBtn.remove();
+      }
+    }
 
     // Handle "Generate New Alias" clicks
     generateAliasBtn.addEventListener("click", async(generateClickEvt) => {

--- a/src/js/add_input_icon.js
+++ b/src/js/add_input_icon.js
@@ -265,16 +265,16 @@ async function addRelayIconToInput(emailInput) {
     restrictOrRestorePageTabbing(-1);
 
     // Append menu elements to the menu
-    [getUnlimitedAliasesBtn, generateAliasBtn, remainingAliasesSpan, relayMenuDashboardLink].forEach(el => {
+    [remainingAliasesSpan, getUnlimitedAliasesBtn, generateAliasBtn, relayMenuDashboardLink].forEach(el => {
       relayInPageMenu.appendChild(el);
     });
 
     //Show get unlimited aliases btn
     if (!premium) {
       if (maxNumAliasesReached) {
-        remainingAliasesSpan.classList.add("max-num-aliases");
         generateAliasBtn.remove();
-        sendInPageEvent("viewed-menu", "input-menu-max-aliases-message")
+        sendInPageEvent("viewed-menu", "input-menu-max-aliases-message");
+        remainingAliasesSpan.textContent = browser.i18n.getMessage("pageFillRelayAddressLimit", [numAliasesRemaining, maxNumAliases]);
       }
 
       else {

--- a/src/js/add_input_icon.js
+++ b/src/js/add_input_icon.js
@@ -286,6 +286,13 @@ async function addRelayIconToInput(emailInput) {
       getUnlimitedAliasesBtn.remove();
     }
 
+    const premiumEnabled = await browser.storage.local.get("premiumEnabled");
+    const premiumEnabledString = premiumEnabled.premiumEnabled;
+
+    if(premiumEnabledString != "True") {
+      getUnlimitedAliasesBtn.remove();
+    }
+
 
     // Handle "Generate New Alias" clicks
     generateAliasBtn.addEventListener("click", async(generateClickEvt) => {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -128,7 +128,7 @@ async function makeRelayAddressForTargetElement(info, tab) {
 
 
 
-async function premiumFeaturesAvailable(premiumEnabledString) {
+function premiumFeaturesAvailable(premiumEnabledString) {
   if (premiumEnabledString === "True") {
     return true;
   }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -162,15 +162,17 @@ async function updateUpgradeContextMenuItem() {
   const premiumEnabledString = premiumEnabled.premiumEnabled;
   const { premium } = await browser.storage.local.get("premium");
 
-  if (!premium && premiumFeaturesAvailable(premiumEnabledString)) {
-    await createUpgradeContextMenuItem();
-  }
+  if (premiumFeaturesAvailable(premiumEnabledString)) {
 
-  // Remove the upgrade item, if the user is upgraded
-  if (!premium && premiumFeaturesAvailable(premiumEnabledString)) {
-    await removeUpgradeContextMenuItem();
-  }
+    if (!premium) {
+      await createUpgradeContextMenuItem();
+    }
 
+    // Remove the upgrade item, if the user is upgraded
+    else {
+      await removeUpgradeContextMenuItem();
+    }
+  }
 }
 
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -134,15 +134,30 @@ if (browser.menus) {
     contexts: ["editable"]
   });
 
+  browser.menus.create({
+    id: "fx-private-relay-get-unlimited-aliases",
+    title: "Get Unlimited Aliases",
+  });
+
   browser.menus.onClicked.addListener( async (info, tab) => {
     switch (info.menuItemId) {
-      case "fx-private-relay-generate-alias":
+      case "fx-private-relay-generate-alias": 
         sendMetricsEvent({
           category: "Extension: Context Menu",
           action: "click",
           label: "context-menu-generate-alias"
         });
         await makeRelayAddressForTargetElement(info, tab);
+        break;
+      case "fx-private-relay-get-unlimited-aliases":
+        sendMetricsEvent({
+          category: "Extension: Context Menu",
+          action: "click",
+          label: "context-menu-get-unlimited-aliases"
+        });
+        const { fxaSubscriptionsUrl, premiumProdId, premiumPriceId } = await browser.storage.local.get();
+        const urlPremium = `${fxaSubscriptionsUrl}/products/${premiumProdId}?plan=${premiumPriceId}`;
+        await browser.tabs.create({ url: urlPremium });
         break;
     }
   });

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -129,10 +129,7 @@ async function makeRelayAddressForTargetElement(info, tab) {
 
 
 function premiumFeaturesAvailable(premiumEnabledString) {
-  if (premiumEnabledString === "True") {
-    return true;
-  }
-  return false;
+  return (premiumEnabledString === "True");
 }
 
 async function createMenu(){
@@ -174,7 +171,7 @@ browser.menus.onClicked.addListener( async (info, tab) => {
           action: "click",
           label: "context-menu-get-unlimited-aliases"
         });
-        const { fxaSubscriptionsUrl, premiumProdId, premiumPriceId } = await browser.storage.local.get();
+        const { fxaSubscriptionsUrl, premiumProdId, premiumPriceId } = await browser.storage.local.get([ "fxaSubscriptionsUrl", "premiumProdId", "premiumPriceId" ]);
         const urlPremium = `${fxaSubscriptionsUrl}/products/${premiumProdId}?plan=${premiumPriceId}`;
         await browser.tabs.create({ url: urlPremium });
         break;

--- a/src/js/fill_relay_address.js
+++ b/src/js/fill_relay_address.js
@@ -27,6 +27,27 @@ async function showModal(modalType) {
   modalMessage.classList = ["fx-relay-modal-message"];
   modalContent.appendChild(modalMessage);
 
+
+  // Create "Get unlimited aliases" button
+  const getUnlimitedAliasesBtn = createElementWithClassList("a", "fx-relay-menu-get-unlimited-aliases");
+  getUnlimitedAliasesBtn.textContent = browser.i18n.getMessage("popupGetUnlimitedAliases");
+  getUnlimitedAliasesBtn.setAttribute("target", "_blank");
+  getUnlimitedAliasesBtn.setAttribute("rel", "noopener noreferrer");
+    
+  //Create "Get unlimited aliases" link
+  const { fxaSubscriptionsUrl } = await browser.storage.local.get("fxaSubscriptionsUrl");
+  const { premiumProdId } = await browser.storage.local.get("premiumProdId");
+  const { premiumPriceId } = await browser.storage.local.get("premiumPriceId");
+  getUnlimitedAliasesBtn.href = `${fxaSubscriptionsUrl}/products/${premiumProdId}?plan=${premiumPriceId}`;
+
+  const premiumEnabled = await browser.storage.local.get("premiumEnabled");
+  const premiumEnabledString = premiumEnabled.premiumEnabled;
+
+  if (premiumEnabledString === "True"){
+    modalContent.appendChild(getUnlimitedAliasesBtn);
+  }
+  
+
   const manageAliasesLink = document.createElement("a");
   manageAliasesLink.textContent = browser.i18n.getMessage("ManageAllAliases");
   manageAliasesLink.classList = ["fx-relay-new-tab fx-relay-modal-manage-aliases"];
@@ -38,7 +59,7 @@ async function showModal(modalType) {
     return window.open(e.target.href);
   });
   modalContent.appendChild(manageAliasesLink);
-  
+
 
   const modalCloseButton = document.createElement("button");
   modalCloseButton.classList = ["fx-relay-modal-close-button"];
@@ -47,7 +68,7 @@ async function showModal(modalType) {
   // Remove relay modal on button click
   modalCloseButton.addEventListener("click", () => {
     sendModalEvent("closed-modal", "modal-closed-btn");
-    modalWrapper.remove();
+    modalContent.remove();
   });
 
   // Remove relay modal on clicks outside of modal.
@@ -59,7 +80,6 @@ async function showModal(modalType) {
     }
   });
 
-  modalContent.appendChild(modalCloseButton);
   modalWrapper.appendChild(modalContent);
   document.body.appendChild(modalWrapper);
   return;

--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -179,7 +179,6 @@
   }
   browser.storage.local.set({relayAddresses});
 
-  console.log("get_profile_data--sendMessage");
   await browser.runtime.sendMessage({
     method: "rebuildContextMenuUpgrade",
   });

--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -178,4 +178,10 @@
     relayAddresses.push(relayAddress);
   }
   browser.storage.local.set({relayAddresses});
+
+  console.log("get_profile_data--sendMessage");
+  await browser.runtime.sendMessage({
+    method: "rebuildContextMenuUpgrade",
+  });
+
 })();


### PR DESCRIPTION
UPDATED DEMO: https://drive.google.com/file/d/12LaQTdpuV9Vfx_2d_OH_2Eir2o8FIBR9/view?usp=sharing

Note: Signing in and out after upgrading to activate premium because I'm using my local server to test - FXA sends its "subscription change event" webhooks to the Relay server url (from @groovecoder). 

This PR should
1) Remove any CTA to upgrade on the context menu/field input popup when `PREMIUM_ENABLED` is set to `False` or when user is already premium
2) Show CTA to upgrade for free users on the context menu/field input popup if `PREMIUM_ENABLED` is set to `True`.
3) Remove `'Generate new alias'` on the field input popup if free user has exhausted all 5 free aliases.