### PR TITLE
Fix #118 - Only show premium UI if premium is enabled [NEW VERSION]

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -157,9 +157,7 @@ async function showRelayPanel(tipPanelToShow) {
     //If Premium features are not available, do not show upgrade CTA on the panel
     if (!premiumFeaturesAvailable(premiumEnabledString)) {
       const premiumCTA = document.querySelector(".premium-cta");
-      const upgradeBanner = document.querySelector(".upgrade-banner-wrapper");
       premiumCTA.classList.add("is-hidden");
-      upgradeBanner.classList.add("is-hidden");
     }
 
     // Remove panel status if user has unlimited aliases, so no negative alias left count
@@ -209,8 +207,11 @@ async function showRelayPanel(tipPanelToShow) {
   relayPanel.classList.remove("hidden");
 
   if (numRemaining === 0) {
-    const upgradeButton = document.querySelector(".upgrade-banner-wrapper");
-    upgradeButton.classList.remove("is-hidden");
+    
+    if (premiumFeaturesAvailable(premiumEnabledString)) {
+      const upgradeButton = document.querySelector(".upgrade-banner-wrapper");
+      upgradeButton.classList.remove("is-hidden");
+    }
 
     return sendRelayEvent("Panel", "viewed-panel", "panel-max-aliases");
   }

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -51,8 +51,8 @@ function showSignUpPanel() {
 }
 
 
-function choosePanel(numRemaining, panelId, premium){
-  if (premium){
+function choosePanel(numRemaining, panelId, premium, premiumEnabledString){
+  if (premium && premiumEnabledString === "True"){
     document.getElementsByClassName("content-wrapper")[0].remove();
     return 'premiumPanel';
   }
@@ -92,15 +92,19 @@ async function showRelayPanel(tipPanelToShow) {
   //Premium Panel
   const premiumPanelWrapper = document.querySelector(".premium-wrapper");
   const registerDomainImgEl = premiumPanelWrapper.querySelector(".email-domain-illustration");
-
   const aliasesUsedValEl = premiumPanelWrapper.querySelector(".aliases-used");
   const emailsBlockedValEl = premiumPanelWrapper.querySelector(".emails-blocked");
   const emailsForwardedValEl = premiumPanelWrapper.querySelector(".emails-forwarded");
 
+  //Check if premium features are available
+  const premiumEnabled = await browser.storage.local.get("premiumEnabled");
+  const premiumEnabledString = premiumEnabled.premiumEnabled;
+
+  //Check if user is premium
   const { premium } = await browser.storage.local.get("premium");
 
   const updatePanel = (numRemaining, panelId) => {
-    const panelToShow = choosePanel(numRemaining, panelId, premium);
+    const panelToShow = choosePanel(numRemaining, panelId, premium, premiumEnabledString);
     onboardingPanelWrapper.classList = [panelToShow];
     const panelStrings = onboardingPanelStrings[`${panelToShow}`];
 
@@ -117,6 +121,15 @@ async function showRelayPanel(tipPanelToShow) {
     emailsBlockedValEl.textContent = emailsBlockedVal;
     emailsForwardedValEl.textContent = emailsForwardedVal;
 
+    //Show premium panel state
+    if (premium && premiumEnabledString === "True"){
+      premiumPanelWrapper.classList.remove("is-hidden");
+      premiumPanelWrapper.querySelectorAll(".is-hidden").forEach(premiumFeature => 
+        premiumFeature.classList.remove("is-hidden") 
+        );
+      //Toggle register domain or education module
+      checkUserSubdomain(premiumSubdomainSet);
+    }
     return;
   };
 
@@ -135,7 +148,6 @@ async function showRelayPanel(tipPanelToShow) {
 
   //Subdomain Data
   const { premiumSubdomainSet } = await browser.storage.local.get("premiumSubdomainSet");
-  checkUserSubdomain(premiumSubdomainSet);
 
 
   //Nonpremium panel status 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -53,27 +53,16 @@ function showSignUpPanel() {
 
 function premiumFeaturesAvailable(premiumEnabledString) {
   if (premiumEnabledString === "True") {
-    return Boolean(true);
+    return true;
   }
-  else {
-    return Boolean(false);
-  }
-}
-
-function enablePremium(premium, premiumEnabledString) {
-  if (premium && premiumFeaturesAvailable(premiumEnabledString)) {
-    return Boolean(true);
-  }
-  else {
-    return Boolean(false);
-  }
+  return false;
 }
 
 
 function choosePanel(numRemaining, panelId, premium, premiumEnabledString, premiumSubdomainSet){
   const premiumPanelWrapper = document.querySelector(".premium-wrapper");
 
-  if (enablePremium(premium, premiumEnabledString)){
+  if (premium && premiumFeaturesAvailable(premiumEnabledString)){
     document.getElementsByClassName("content-wrapper")[0].remove();
     premiumPanelWrapper.classList.remove("is-hidden");
     premiumPanelWrapper.querySelectorAll(".is-hidden").forEach(premiumFeature => 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -298,8 +298,17 @@ async function popup() {
     registerDomainLink.href = `${relaySiteOrigin}/accounts/profile`;
   });
 
+  const premiumEnabled = await browser.storage.local.get("premiumEnabled");
+  const premiumEnabledString = premiumEnabled.premiumEnabled;
   const { premium } = await browser.storage.local.get("premium");
 
+  //If Premium features are available, show upgrade CTA
+  if (premiumEnabledString === "True") {
+    const premiumCTA = document.querySelector(".premium-cta");
+    premiumCTA.classList.remove("is-hidden");
+  }
+
+  //if user is premium, hide panel status
   if (!premium) {  
     const panelStatus = document.querySelector(".panel-status");
     panelStatus.classList.remove("is-hidden");

--- a/src/popup.html
+++ b/src/popup.html
@@ -51,7 +51,7 @@
         <span class="panel-status">
           <p class="aliases-remaining remaining-plural"></p>
           <a 
-            class="premium-cta is-hidden i18n-content close-popup-after-click button get-premium-link" 
+            class="premium-cta i18n-content close-popup-after-click button get-premium-link" 
             data-event-action="click"
             data-i18n-message-id="popupGetUnlimitedAliases"
             >
@@ -63,7 +63,7 @@
             <img class="onboarding-img">
             <h1 class="onboarding-h1"></h1>
             <p class="onboarding-p"></p>
-            <a class="upgrade-banner-wrapper is-hidden close-popup-after-click button get-premium-link is-hidden" data-event-action="click">
+            <a class="upgrade-banner-wrapper is-hidden close-popup-after-click button get-premium-link" data-event-action="click">
               <img class="upgrade-banner-icon">
               <p class="upgrade-banner"></p>
             </a>

--- a/src/popup.html
+++ b/src/popup.html
@@ -77,8 +77,9 @@
             </div>
           </div>
           <!-- Premium Panel-->
-          <div class="premium-wrapper">
-            <div class="premium-dashboard">
+          <div class="premium-wrapper is-hidden">
+            <!-- Premium Dashboard-->
+            <div class="premium-dashboard is-hidden">
               <ul>
                 <li class="dashboard-info">
                   <span class="aliases-used-text i18n-content" data-i18n-message-id="popupAliasesUsed"></span>
@@ -94,12 +95,14 @@
                 </li>
               </ul>
             </div>
-            <div class="register-domain-component">
+            <!-- Premium Dashboard-->
+            <div class="register-domain-component is-hidden">
               <p class="register-domain-headline i18n-content" data-i18n-message-id="popupRegisterDomainHeadline"></p>
               <img class="email-domain-illustration">
               <a class="register-domain-cta i18n-content button sign-in-btn blue-primary-btn close-popup-after-click" data-event-action="click" data-i18n-message-id="popupRegisterDomainButton"></a> 
             </div>
-            <div class="educational-component">
+            <!-- Educational Matrix Module Dashboard-->
+            <div class="educational-component is-hidden">
               <img class="education-img">
               <div class="education-description">
                 <h1 class="education-headline i18n-content" data-i18n-message-id="popupEducationalComponent1Headline"></h1>

--- a/src/popup.html
+++ b/src/popup.html
@@ -48,7 +48,7 @@
       </sign-up-panel>
 
       <main-panel class="signed-in-panel hidden">
-        <span class="panel-status is-hidden">
+        <span class="panel-status">
           <p class="aliases-remaining remaining-plural"></p>
           <a 
             class="premium-cta is-hidden i18n-content close-popup-after-click button get-premium-link" 
@@ -63,7 +63,7 @@
             <img class="onboarding-img">
             <h1 class="onboarding-h1"></h1>
             <p class="onboarding-p"></p>
-            <a class="upgrade-banner-wrapper close-popup-after-click button get-premium-link is-hidden" data-event-action="click">
+            <a class="upgrade-banner-wrapper is-hidden close-popup-after-click button get-premium-link is-hidden" data-event-action="click">
               <img class="upgrade-banner-icon">
               <p class="upgrade-banner"></p>
             </a>

--- a/src/popup.html
+++ b/src/popup.html
@@ -51,7 +51,7 @@
         <span class="panel-status is-hidden">
           <p class="aliases-remaining remaining-plural"></p>
           <a 
-            class="premium-cta i18n-content close-popup-after-click button get-premium-link" 
+            class="premium-cta is-hidden i18n-content close-popup-after-click button get-premium-link" 
             data-event-action="click"
             data-i18n-message-id="popupGetUnlimitedAliases"
             >


### PR DESCRIPTION
[REVISED PR]

This PR:

- Takes into account the value of `settings.PREMIUM_ENABLED`, which checks whether premium features are available on the site.

- So if the aforementioned value doesn't return True, the add on defaults back to a 'non-premium' view.

- All premium UI blocks now have a `is-hidden` utility class.
