### PR TITLE
Allow saving an alias label by pressing Enter

### DIFF
--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -48,7 +48,7 @@
 
     const aliasLabelForm = aliasCard.querySelector("form.relay-email-address-label-form");
     const aliasLabelInput = aliasCard.querySelector("input.relay-email-address-label");
-    const aliasLabelWrapper = aliasLabelForm.parentElement;
+    const aliasLabelWrapper = (aliasLabelForm ?? aliasLabelInput).parentElement;
     aliasLabelWrapper.classList.add("show-label"); // Field is visible only to users who have the addon installed
 
     aliasLabelInput.dataset.label = storedAliasLabel;
@@ -155,7 +155,7 @@
 
     };
     aliasLabelInput.addEventListener("focusout", saveAliasLabel);
-    aliasLabelForm.addEventListener("submit", (event) => {
+    aliasLabelForm?.addEventListener("submit", (event) => {
       event.preventDefault();
       saveAliasLabel();
       aliasLabelInput.blur();

--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -46,8 +46,9 @@
     const defaultAliasLabelText = browser.i18n.getMessage("profilePageDefaulAliasLabelText");
     const storedAliasLabel = (addonRelayAddress && addonRelayAddress.hasOwnProperty("domain")) ? addonRelayAddress.domain : "";
 
+    const aliasLabelForm = aliasCard.querySelector("form.relay-email-address-label-form");
     const aliasLabelInput = aliasCard.querySelector("input.relay-email-address-label");
-    const aliasLabelWrapper = aliasLabelInput.parentElement;
+    const aliasLabelWrapper = aliasLabelForm.parentElement;
     aliasLabelWrapper.classList.add("show-label"); // Field is visible only to users who have the addon installed
 
     aliasLabelInput.dataset.label = storedAliasLabel;
@@ -115,7 +116,7 @@
       }
     });
 
-    aliasLabelInput.addEventListener("focusout", () => {
+    const saveAliasLabel = () => {
       const newAliasLabel = aliasLabelInput.value;
 
       // Don't save labels containing forbidden characters
@@ -148,10 +149,16 @@
       }
 
       aliasLabelInput.dataset.label = newAliasLabel;
-      setTimeout(()=> {
+      setTimeout(() => {
         aliasLabelWrapper.classList.remove("show-saved-confirmation");
       }, 1000);
 
+    };
+    aliasLabelInput.addEventListener("focusout", saveAliasLabel);
+    aliasLabelForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      saveAliasLabel();
+      aliasLabelInput.blur();
     });
 
     // Get and store the relay addresses from the account profile page,


### PR DESCRIPTION
With this PR, pressing <kbd>Enter</kbd> when editing an alias label will save that label. Note that it will only work once changes in https://github.com/mozilla/fx-private-relay/pull/1078 are also applied.

Commit eb1c70825f4b8418612feef11644d8816a8dca0b should make this backwards compatible, i.e. to make sure the add-on continues to work if this change is applied before the change on the website is. I'm not sure what our strategy in that regard is. Unfortunately, making it backwards compatible the other way around (i.e. changing the website in a way that an older version of the add-on will continue to work) isn't really feasible I think, since the add-on is pretty bound to the specific DOM structure.

Also, just to check: I don't think there usually are tests for this kind of change? If there are, I'd appreciate any pointers :)

/cc @maxxcrawford 