### PR TITLE
Store the original site when generating a new alias from the add-on

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -88,7 +88,10 @@ async function makeRelayAddress(domain=null) {
   }
   let newRelayAddressJson = await newRelayAddressResponse.json();
   if (domain) {
+    // TODO: Update the domain attribute to be "label"
     newRelayAddressJson.domain = domain;
+    // Store the domain in which the alias was generated, separate from the label 
+    newRelayAddressJson.siteOrigin = domain;
   }
   // TODO: put this into an updateLocalAddresses() function
   const localStorageRelayAddresses = await browser.storage.local.get("relayAddresses");

--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -45,6 +45,10 @@
 
     const defaultAliasLabelText = browser.i18n.getMessage("profilePageDefaulAliasLabelText");
     const storedAliasLabel = (addonRelayAddress && addonRelayAddress.hasOwnProperty("domain")) ? addonRelayAddress.domain : "";
+    
+    // Cache the siteOrigin alias attribute when updating local storage data.
+    // Note that this data attribute only exists in aliases generated through the add-on
+    const storedAliasSiteOrigin = (addonRelayAddress && addonRelayAddress.hasOwnProperty("siteOrigin")) ? addonRelayAddress.siteOrigin : "";
 
     const aliasLabelForm = aliasCard.querySelector("form.relay-email-address-label-form");
     const aliasLabelInput = aliasCard.querySelector("input.relay-email-address-label");
@@ -168,6 +172,7 @@
       "id": aliasId,
       "address": aliasCardData.relayAddress,
       "domain": storedAliasLabel,
+      "siteOrigin": storedAliasSiteOrigin,
     };
 
     relayAddresses.push(relayAddress);

--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -48,7 +48,7 @@
     
     // Cache the siteOrigin alias attribute when updating local storage data.
     // Note that this data attribute only exists in aliases generated through the add-on
-    const storedAliasSiteOrigin = (addonRelayAddress && addonRelayAddress.hasOwnProperty("siteOrigin")) ? addonRelayAddress.siteOrigin : "";
+    const storedAliasSiteOrigin = addonRelayAddress?.siteOrigin ?? "";
 
     const aliasLabelForm = aliasCard.querySelector("form.relay-email-address-label-form");
     const aliasLabelInput = aliasCard.querySelector("input.relay-email-address-label");


### PR DESCRIPTION
This PR adds a new data point to aliases generated from the add-on. This data attribute will be used in a later release to recommend labels to be reused on sites that match the same domain

Note that this data is only stored locally for the user. In a future release, we will use this information to display an already generated alias on sites that match the site origin data attribute. 

This PR fixes MPP-847 

## Testing 

- To verify, generate a new alias using the content script/context menu from a website
- Debug the add-on and run the following command in the console. This will return an array of all your created aliases. Look at the alias you just created: 

  ` await browser.storage.local.get("relayAddresses")`

- **Expected:**  The first item in the array (newest created alias) should contain the root domain (same value that matches the inital label value) in the `siteOrigin` property. 
- Edit the label to something else. Re-run the console command.
- **Expected: ** The array should now return the revised label with the siteOrigin unchanged. 