### PR TITLE
Add context menu to reuse aliases

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,203 +1,195 @@
-const RELAY_SITE_ORIGIN = "http://127.0.0.1:8000";
+(async function () {
+  const RELAY_SITE_ORIGIN = "http://127.0.0.1:8000";
 
-browser.storage.local.set({ "maxNumAliases": 5 });
-browser.storage.local.set({ "relaySiteOrigin": RELAY_SITE_ORIGIN });
+  browser.storage.local.set({ maxNumAliases: 5 });
+  browser.storage.local.set({ relaySiteOrigin: RELAY_SITE_ORIGIN });
 
+  const localStorage = await browser.storage.local.get();
 
-browser.runtime.onInstalled.addListener(async () => {
-  const { firstRunShown } = await browser.storage.local.get("firstRunShown");
-  if (firstRunShown) {
-    return;
-  }
-  const userApiToken = await browser.storage.local.get("apiToken");
-  const apiKeyInStorage = (userApiToken.hasOwnProperty("apiToken"));
-  const url = browser.runtime.getURL("first-run.html");
-  if (!apiKeyInStorage) {
-    await browser.tabs.create({ url });
-    browser.storage.local.set({ "firstRunShown" : true });
-  }
-});
-
-
-// https://stackoverflow.com/a/2117523
-function uuidv4() {
-  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  );
-}
-
-
-async function getOrMakeGAUUID() {
-  const { ga_uuid } = await browser.storage.local.get("ga_uuid");
-  if (ga_uuid) {
-    return ga_uuid;
-  }
-  const newGAUUID = uuidv4();
-  await browser.storage.local.set({ "ga_uuid": newGAUUID });
-  return newGAUUID;
-}
-
-
-async function sendMetricsEvent(eventData) {
-  const doNotTrackIsEnabled = (navigator.doNotTrack === "1");
-  const { dataCollection } = await browser.storage.local.get("dataCollection");
-
-  if (!dataCollection) {
-    browser.storage.local.set({ "dataCollection": "data-enabled" });
+  if (!localStorage.existingAliasContextMenu) {
+    browser.storage.local.set({ existingAliasContextMenu: false });
   }
 
-  if (dataCollection !== "data-enabled" || doNotTrackIsEnabled) {
-    return;
-  }
-
-  const ga_uuid = await getOrMakeGAUUID();
-  const eventDataWithGAUUID = Object.assign({ga_uuid}, eventData);
-  const sendMetricsEventUrl = `${RELAY_SITE_ORIGIN}/metrics-event`;
-  fetch(sendMetricsEventUrl, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json"
-    },
-    body: JSON.stringify(eventDataWithGAUUID),
+  browser.runtime.onInstalled.addListener(async () => {
+    const { firstRunShown } = await browser.storage.local.get("firstRunShown");
+    if (firstRunShown) {
+      return;
+    }
+    const userApiToken = await browser.storage.local.get("apiToken");
+    const apiKeyInStorage = userApiToken.hasOwnProperty("apiToken");
+    const url = browser.runtime.getURL("first-run.html");
+    if (!apiKeyInStorage) {
+      await browser.tabs.create({ url });
+      browser.storage.local.set({ firstRunShown: true });
+    }
   });
-}
 
+  // https://stackoverflow.com/a/2117523
+  function uuidv4() {
+    return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
+      (
+        c ^
+        (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
+      ).toString(16)
+    );
+  }
 
-async function makeRelayAddress(domain=null) {
-  const apiToken = await browser.storage.local.get("apiToken");
+  async function getOrMakeGAUUID() {
+    const { ga_uuid } = await browser.storage.local.get("ga_uuid");
+    if (ga_uuid) {
+      return ga_uuid;
+    }
+    const newGAUUID = uuidv4();
+    await browser.storage.local.set({ ga_uuid: newGAUUID });
+    return newGAUUID;
+  }
 
-  if (!apiToken.apiToken) {
+  async function sendMetricsEvent(eventData) {
+    const doNotTrackIsEnabled = navigator.doNotTrack === "1";
+    const { dataCollection } = await browser.storage.local.get(
+      "dataCollection"
+    );
 
-    browser.tabs.create({
-      url: RELAY_SITE_ORIGIN,
+    if (!dataCollection) {
+      browser.storage.local.set({ dataCollection: "data-enabled" });
+    }
+
+    if (dataCollection !== "data-enabled" || doNotTrackIsEnabled) {
+      return;
+    }
+
+    const ga_uuid = await getOrMakeGAUUID();
+    const eventDataWithGAUUID = Object.assign({ ga_uuid }, eventData);
+    const sendMetricsEventUrl = `${RELAY_SITE_ORIGIN}/metrics-event`;
+    fetch(sendMetricsEventUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(eventDataWithGAUUID),
     });
-    return;
   }
 
-  const newRelayAddressUrl = `${RELAY_SITE_ORIGIN}/emails/`;
-  const newRelayAddressResponse = await fetch(newRelayAddressUrl, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: `api_token=${apiToken.apiToken}`
-  });
-  if (newRelayAddressResponse.status === 402) {
-    // FIXME: can this just return newRelayAddressResponse ?
-    return {status: 402};
-  }
-  let newRelayAddressJson = await newRelayAddressResponse.json();
-  if (domain) {
-    // TODO: Update the domain attribute to be "label"
-    newRelayAddressJson.domain = domain;
-    // Store the domain in which the alias was generated, separate from the label 
-    newRelayAddressJson.siteOrigin = domain;
-  }
-  // TODO: put this into an updateLocalAddresses() function
-  const localStorageRelayAddresses = await browser.storage.local.get("relayAddresses");
-  const localRelayAddresses = (Object.keys(localStorageRelayAddresses).length === 0) ? {relayAddresses: []} : localStorageRelayAddresses;
-  const updatedLocalRelayAddresses = localRelayAddresses.relayAddresses.concat([newRelayAddressJson]);
-  browser.storage.local.set({relayAddresses: updatedLocalRelayAddresses});
-  return newRelayAddressJson;
-}
+  async function makeRelayAddress(domain = null) {
+    const apiToken = await browser.storage.local.get("apiToken");
 
-async function makeRelayAddressForTargetElement(info, tab) {
-  const pageUrl = new URL(info.pageUrl);
-  const newRelayAddress = await makeRelayAddress(pageUrl.hostname);
+    if (!apiToken.apiToken) {
+      browser.tabs.create({
+        url: RELAY_SITE_ORIGIN,
+      });
+      return;
+    }
 
-  if (newRelayAddress.status === 402) {
+    const newRelayAddressUrl = `${RELAY_SITE_ORIGIN}/emails/`;
+    const newRelayAddressResponse = await fetch(newRelayAddressUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: `api_token=${apiToken.apiToken}`,
+    });
+    if (newRelayAddressResponse.status === 402) {
+      // FIXME: can this just return newRelayAddressResponse ?
+      return { status: 402 };
+    }
+    let newRelayAddressJson = await newRelayAddressResponse.json();
+    if (domain) {
+      // TODO: Update the domain attribute to be "label"
+      newRelayAddressJson.domain = domain;
+      // Store the domain in which the alias was generated, separate from the label
+      newRelayAddressJson.siteOrigin = domain;
+    }
+    // TODO: put this into an updateLocalAddresses() function
+    const localStorageRelayAddresses = await browser.storage.local.get(
+      "relayAddresses"
+    );
+    const localRelayAddresses =
+      Object.keys(localStorageRelayAddresses).length === 0
+        ? { relayAddresses: [] }
+        : localStorageRelayAddresses;
+    const updatedLocalRelayAddresses =
+      localRelayAddresses.relayAddresses.concat([newRelayAddressJson]);
+    browser.storage.local.set({ relayAddresses: updatedLocalRelayAddresses });
+
+    // await updateContextMenuItems();
+
+    return newRelayAddressJson;
+  }
+
+  async function makeRelayAddressForTargetElement(info, tab) {
+    const pageUrl = new URL(info.pageUrl);
+    const newRelayAddress = await makeRelayAddress(pageUrl.hostname);
+
+    if (newRelayAddress.status === 402) {
+      browser.tabs.sendMessage(tab.id, {
+        type: "showMaxNumAliasesMessage",
+      });
+      return;
+    }
+
     browser.tabs.sendMessage(
       tab.id,
       {
-        type: "showMaxNumAliasesMessage",
-      });
-    return;
-  }
-
-  browser.tabs.sendMessage(
-      tab.id,
-      {
         type: "fillTargetWithRelayAddress",
-        targetElementId : info.targetElementId,
+        targetElementId: info.targetElementId,
         relayAddress: newRelayAddress,
       },
       {
         frameId: info.frameId,
-    },
-  );
-}
+      }
+    );
+  }
 
-async function fillInAddressWithAliasId(info, tab) {
-  // Trim the context menu id to get the alias reference ID
-  const selectedAliasId = info.menuItemId.replace("fx-private-relay-use-existing-alias_", "");
+  async function fillInAddressWithAliasId(info, tab) {
+    // Trim the context menu id to get the alias reference ID
+    const selectedAliasId = info.menuItemId.replace(
+      "fx-private-relay-use-existing-alias_",
+      ""
+    );
 
-  // Get stored alias data
-  const { relayAddresses } = await browser.storage.local.get("relayAddresses");
+    // Get stored alias data
+    const { relayAddresses } = await browser.storage.local.get(
+      "relayAddresses"
+    );
 
-  // Select the correct alias from the stored alias data
-  const selectedAliasObject = relayAddresses.filter(obj => {
-    return obj.id === selectedAliasId
-  })
+    // Select the correct alias from the stored alias data
+    const selectedAliasObject = relayAddresses.filter((obj) => {
+      return obj.id === selectedAliasId;
+    });
 
-  // console.log({
-  //   tabId: tab.id,
-  //   targetElementId: info.targetElementId,
-  //   relayAddress: selectedEmailAddress,
-  //   frameId: info.frameId
-  // });
+    //   tabId: tab.id,
+    //   targetElementId: info.targetElementId,
+    //   relayAddress: selectedEmailAddress,
+    //   frameId: info.frameId
+    // });
 
-  browser.tabs.sendMessage(
+    browser.tabs.sendMessage(
       tab.id,
       {
         type: "fillTargetWithRelayAddress",
-        targetElementId : info.targetElementId,
+        targetElementId: info.targetElementId,
         relayAddress: selectedAliasObject[0],
       },
       {
         frameId: info.frameId,
-    },
-  );
+      }
+    );
+  }
 
-}
-
-function addAliasToExistingAliasContextMenu(alias, parentId) {
-  
-  // If there's a label. Set the context menu item title accordingly.
-  const title = (alias.domain ? alias.domain : alias.address);
-  const id = "fx-private-relay-use-existing-alias_" + alias.id; 
-  
-  browser.menus.create({
-    id,
-    type: "radio",
-    title,
-    parentId,
-  });
-}
-
-async function generateAliasesContextMenu(aliases, opts) {
-  
-  if ( opts?.siteOrigin ) {
-
-    const parentSiteOriginId = "fx-private-relay-use-existing-aliases-from-this-site";
+  function addAliasToExistingAliasContextMenu(alias, parentId) {
+    // If there's a label. Set the context menu item title accordingly.
+    const title = alias.domain ? alias.domain : alias.address;
+    const id = "fx-private-relay-use-existing-alias_" + alias.id;
 
     browser.menus.create({
-      id: parentSiteOriginId,
-      title: "Use existing alias from this site…",
+      id,
+      type: "radio",
+      title,
+      parentId,
     });
+  }
 
-    for (const alias of aliases) {
-      addAliasToExistingAliasContextMenu(alias, parentSiteOriginId);
-    }
-
-    // WIP Code - If adding a separator.
-    // browser.menus.create({
-    //   id: parentSiteOriginId,
-    //   type: "separator",
-    //   title: "Use existing alias from this site…",
-    // });
-
-  } else {
-
+  async function generateAliasesContextMenu(aliases) {
     const parentNonSiteOriginId = "fx-private-relay-use-existing-aliases";
 
     // TODO: Set l10n for title
@@ -210,106 +202,131 @@ async function generateAliasesContextMenu(aliases, opts) {
       addAliasToExistingAliasContextMenu(alias, parentNonSiteOriginId);
     }
   }
-}
 
-async function initExistingAliasContextMenu() {
-  const { relayAddresses } = await browser.storage.local.get("relayAddresses");
-  const selectableAddressesArray = [];
-  const siteOriginAddressesArray = [];
-  const nonSiteOriginAddressesArray = [];
+  async function updateContextMenuItems(addressId) {
+    const { relayAddresses } = await browser.storage.local.get();
+    const updatedRelayAddress = relayAddresses.filter(
+      (address) => address.id == addressId
+    )[0];
 
-  const sortableAddress = relayAddresses;
+    // updateContextMenuItems;
+    const id = "fx-private-relay-use-existing-alias_" + updatedRelayAddress.id;
+    const parentId = "fx-private-relay-use-existing-aliases";
+    const title = updatedRelayAddress.domain
+      ? updatedRelayAddress.domain
+      : updatedRelayAddress.address;
 
-  // BUG: We need to query all aliases to see if any items siteOrigin attr 
-  // match the current site, rather than looping over the first five items. 
-  // This will change this forLoop dramatically.
+    browser.menus.update(
+      id, // integer or string
+      {
+        type: "radio",
+        title,
+        parentId,
+      }
+    );
+  }
 
-  for (let index = 0; index < 5; index++) {
-    const element = sortableAddress[index];
+  async function initExistingAliasContextMenu() {
+    const { relayAddresses, existingAliasContextMenu } =
+      await browser.storage.local.get();
 
-    // The ID (regardless of site origin) needs to be generated and stored during this first loop. 
-    // The selectableAddressesArray is used to add the event listener to fillInAddressWithAliasId;
-    const id = "fx-private-relay-use-existing-alias_" + element.id; 
-    selectableAddressesArray.push(id);
+    if (existingAliasContextMenu) {
+      // Don't try to rebuild the menu. It exists!
+      return;
+    }
 
-    
-    if (element.siteOrigin) {
-      siteOriginAddressesArray.push(element);
-    } else {
+    // Set flag that the browser menu has been created
+    browser.storage.local.set({ existingAliasContextMenu: true });
+
+    const selectableAddressesArray = [];
+    const nonSiteOriginAddressesArray = [];
+
+    const sortableAddress = relayAddresses;
+
+    // BUG: We need to query all aliases to see if any items siteOrigin attr
+    // match the current site, rather than looping over the first five items.
+    // This will change this forLoop dramatically.
+
+    for (let index = 0; index < 5; index++) {
+      const element = sortableAddress[index];
+
+      if (!element) {
+        break;
+      }
+
+      // The ID (regardless of site origin) needs to be generated and stored during this first loop.
+      // The selectableAddressesArray is used to add the event listener to fillInAddressWithAliasId;
+      const id = "fx-private-relay-use-existing-alias_" + element.id;
+      selectableAddressesArray.push(id);
       nonSiteOriginAddressesArray.push(element);
-    }   
-  }
-
-  // If there are aliases generated on the current site, add those first.
-  if (siteOriginAddressesArray.length > 0) {
-    generateAliasesContextMenu(siteOriginAddressesArray, {"siteOrigin": true});
-  }
-
-  // Add rest of the available aliases to the context menu
-  if (nonSiteOriginAddressesArray.length > 0) {
-    generateAliasesContextMenu(nonSiteOriginAddressesArray);
-  }
-
-  browser.menus.onClicked.addListener( async (info, tab) => {
-    if ( selectableAddressesArray.includes(info.menuItemId) ) {
-      await fillInAddressWithAliasId(info, tab);
     }
-  });
 
-}
+    // Add rest of the available aliases to the context menu
+    if (nonSiteOriginAddressesArray.length > 0) {
+      generateAliasesContextMenu(nonSiteOriginAddressesArray);
+    }
 
-if (browser.menus) {
+    browser.menus.onClicked.addListener(async (info, tab) => {
+      if (selectableAddressesArray.includes(info.menuItemId)) {
+        await fillInAddressWithAliasId(info, tab);
+      }
+    });
+  }
 
-  // TODO: Set enabled to false if max aliases reached on free tier 
-  browser.menus.create({
-    id: "fx-private-relay-generate-alias",
-    title: "Generate New Alias",
-    contexts: ["editable"]
-  });
+  if (browser.menus) {
+    // TODO: Set enabled to false if max aliases reached on free tier
+    browser.menus.create({
+      id: "fx-private-relay-generate-alias",
+      title: "Generate New Alias",
+      contexts: ["editable"],
+    });
 
-  initExistingAliasContextMenu();
+    browser.menus.onClicked.addListener(async (info, tab) => {
+      switch (info.menuItemId) {
+        case "fx-private-relay-generate-alias":
+          sendMetricsEvent({
+            category: "Extension: Context Menu",
+            action: "click",
+            label: "context-menu-generate-alias",
+          });
+          await makeRelayAddressForTargetElement(info, tab);
+          break;
+      }
+    });
 
-  browser.menus.onClicked.addListener( async (info, tab) => {
-    switch (info.menuItemId) {
-      case "fx-private-relay-generate-alias":
-        sendMetricsEvent({
-          category: "Extension: Context Menu",
-          action: "click",
-          label: "context-menu-generate-alias"
+    browser.menus.onShown.addListener(async (info, tab) => {
+      switch (info.menuItemId) {
+        case "fx-private-relay-use-existing-aliases":
+          break;
+      }
+    });
+  }
+
+  browser.runtime.onMessage.addListener(async (m) => {
+    let response;
+
+    switch (m.method) {
+      case "makeRelayAddress":
+        response = await makeRelayAddress(m.domain);
+        break;
+      case "updateInputIconPref":
+        browser.storage.local.set({ showInputIcons: m.iconPref });
+        break;
+      case "openRelayHomepage":
+        browser.tabs.create({
+          url: `${RELAY_SITE_ORIGIN}?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=go-to-fx-relay`,
         });
-        await makeRelayAddressForTargetElement(info, tab);
+        break;
+      case "sendMetricsEvent":
+        response = await sendMetricsEvent(m.eventData);
+        break;
+      case "createExistingAliasContextMenu":
+        initExistingAliasContextMenu();
+        break;
+      case "updateExistingAliasContextMenu":
+        await updateContextMenuItems(m.id);
         break;
     }
+    return response;
   });
-
-  browser.menus.onShown.addListener( async (info, tab) => {
-    switch (info.menuItemId) {
-      case "fx-private-relay-use-existing-aliases":
-        console.log("fx-private-relay-use-existing-aliases", info.contexts);
-        break;
-    }
-  });
-
-}
-
-browser.runtime.onMessage.addListener(async (m) => {
-  let response;
-
-  switch (m.method) {
-    case "makeRelayAddress":
-      response = await makeRelayAddress(m.domain);
-      break;
-    case "updateInputIconPref":
-      browser.storage.local.set({ "showInputIcons" : m.iconPref });
-      break;
-    case "openRelayHomepage":
-      browser.tabs.create({
-        url: `${RELAY_SITE_ORIGIN}?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=go-to-fx-relay`,
-      });
-      break;
-    case "sendMetricsEvent":
-      response = await sendMetricsEvent(m.eventData);
-      break;
-  }
-  return response;
-});
+})();

--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -157,6 +157,8 @@
         aliasLabelWrapper.classList.remove("show-saved-confirmation");
       }, 1000);
 
+      updateBackgroundScript(updatedRelayAddress.id);
+
     };
     aliasLabelInput.addEventListener("focusout", saveAliasLabel);
     aliasLabelForm?.addEventListener("submit", (event) => {
@@ -178,4 +180,18 @@
     relayAddresses.push(relayAddress);
   }
   browser.storage.local.set({relayAddresses});
+
+  // await browser.runtime.sendMessage({
+  //   method: "createExistingAliasContextMenu",
+  // });
+
+
+  async function updateBackgroundScript(id) {
+    console.log("updateBackgroundScript", id);
+    await browser.runtime.sendMessage({
+      method: "updateExistingAliasContextMenu",
+      id,
+    });
+  }
+
 })();


### PR DESCRIPTION
Fixes MPP-833

TODO: 
- [ ] Query all aliases `siteOrigin` attribute to see if they match the current site. 
- [ ] Move context menu strings to L10N (Need copy approval from Chris Rooney)
- [ ] (Possible) Add up to five aliases for each menu
- [ ] Log ping with this interaction

Test/Edgecases: 
- User has no aliases generated from the current site
- User has 1-4 aliases generated from the current site
- User has more than five items, all generated from the same site 
- User has some labels set for aliases 

Screenshots:

<img width="724" alt="image" src="https://user-images.githubusercontent.com/2692333/134197905-802d0e8c-28f1-41a9-931f-0e6f7bc8fdf8.png">

<img width="773" alt="image" src="https://user-images.githubusercontent.com/2692333/134197913-69cd8d17-6fd5-47ea-a714-53585ab741c2.png">


