### PR TITLE
Use an inline wrapper for input fields

### DIFF
--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -348,6 +348,7 @@ button.fx-relay-menu-generate-alias-btn[disabled] {
 }
 
 .fx-relay-email-input-wrapper {
+  display: inline-block;
   position: relative;
   pointer-events: none;
   padding: 0 !important;

--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -135,7 +135,7 @@ async function addRelayIconToInput(emailInput) {
 
   // create new wrapping element;
   const emailInputWrapper = createElementWithClassList(
-    "div",
+    "span",
     "fx-relay-email-input-wrapper"
   );
   emailInputOriginalParentEl.insertBefore(emailInputWrapper, emailInput);


### PR DESCRIPTION
Fixes # #143.

The input field at https://www.cookson-clal.com/login_in.jsp?country=gb&shop=c&language=FRA&site400=001&company=004&siteid=IC is not clickable - our `<div>` wrapper around the input is inside a `<span>` wrapper by the site. As far as I can see there's no need for our wrapper to be a block-level element.