### PR TITLE
Disallow whitespace-only labels

### DIFF
--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -388,7 +388,12 @@
           aliasLabelWrapper.classList.remove("show-saved-confirmation");
         }, 1000);
       };
-      aliasLabelInput.addEventListener("focusout", saveAliasLabel);
+      aliasLabelInput.addEventListener("focusout", () => {
+        const isValid = aliasLabelForm.reportValidity();
+        if (isValid) {
+          saveAliasLabel();
+        }
+      });
       aliasLabelForm?.addEventListener("submit", (event) => {
         event.preventDefault();
         saveAliasLabel();


### PR DESCRIPTION
Fixes #104.

Using the `pattern` attribute doesn't provide a particularly
helpful error message, but since it's pretty clear what you're
doing wrong if you're only inserting whitespace, and also not
something people often do, I think that's probably fine.

Also requires https://github.com/mozilla/fx-private-relay/pull/1191.