### PR TITLE
Add a badge counting remaining aliases

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -225,7 +225,32 @@ async function showRelayPanel(tipPanelToShow) {
   //Check if user has a subdomain set
   const { premiumSubdomainSet } = await browser.storage.local.get("premiumSubdomainSet");
 
+  const updateBadge = (numRemaining) => {
+    if (premium) {
+      // Premium users have unlimited aliases, so we don't need to list the remaining number:
+      return;
+    }
+    browser.browserAction.setBadgeText({ text: (numRemaining >= 0) ? numRemaining.toString() : "" });
+    if (numRemaining === 0) {
+      browser.browserAction.setBadgeBackgroundColor({
+        color: "#810220",
+      });
+      browser.browserAction.setBadgeTextColor({
+        color: "white",
+      });
+    }
+    if (numRemaining > 0) {
+      browser.browserAction.setBadgeBackgroundColor({
+        color: "#ffd567",
+      });
+      browser.browserAction.setBadgeTextColor({
+        color: "black",
+      });
+    }
+  }
+
   const updatePanel = async (numRemaining, panelId) => {
+    updateBadge(numRemaining);
     const panelToShow = await choosePanel(numRemaining, panelId, premium, premiumEnabledString, premiumSubdomainSet);
     onboardingPanelWrapper.classList = [panelToShow];
     const panelStrings = onboardingPanelStrings[`${panelToShow}`];


### PR DESCRIPTION
Fixes #163.

Unfortunately the add-on is not always in sync with the back-end (related: https://github.com/mozilla/fx-private-relay/issues/1220).
This means that if you add new aliases or delete an existing alias
somewhere other than from within the popup menu, the badge will
not be up-to-date until you open the popup again.

Up to Eduardo to verify whether this is acceptable UX, or if we'd prefer no badge.

https://user-images.githubusercontent.com/4251/137499185-3cc087e9-db27-4549-8277-89bd3b983042.mp4

