### PR TITLE
Fix #168 - Force Page Refresh on Dashboard Page when updating settings

### DIFF
--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -410,4 +410,5 @@
   await browser.runtime.sendMessage({
     method: "rebuildContextMenuUpgrade",
   });
+
 })();

--- a/src/js/settings_refresh.js
+++ b/src/js/settings_refresh.js
@@ -1,0 +1,3 @@
+(async function () {
+  browser.storage.local.set({ settingsRefresh: false });
+})();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -46,6 +46,12 @@
     },
     {
       "matches": [
+          "http://127.0.0.1/accounts/settings/**"
+      ],
+      "js": ["js/settings_refresh.js"]
+    },
+    {
+      "matches": [
           "<all_urls>"
       ],
       "js": ["js/utils.js", "js/fathom.js", "js/email_detector.js", "js/add_input_icon.js", "js/fill_relay_address.js", "js/metrics.js"],


### PR DESCRIPTION
Add force page refresh whenever a user visited the dashboard page, navigating from the settings page