### PR TITLE
Update subdoman registration prompt link, add UTMs

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -447,7 +447,7 @@ async function popup() {
   });
 
   document.querySelectorAll(".register-domain-cta").forEach(registerDomainLink => {
-    registerDomainLink.href = `${relaySiteOrigin}/accounts/profile`;
+    registerDomainLink.href = `${relaySiteOrigin}/accounts/profile?utm_source=fx-relay-addon&utm_medium=popup&utm_content=register-email-domain#mpp-choose-subdomain`;
   });
 
 }


### PR DESCRIPTION
## Testing Steps

- Login with premium account, NO subdomain registered
- **Expected:** When you click on the popup, you should get a prompt to register a subdomain
- Click on "Register Email Domain" 
- **Expected:** New tab is opened to the dashboard, with the domain registration banner scrolled down into view (and also added UTMs) 

Preview 
<img width="413" alt="image" src="https://user-images.githubusercontent.com/2692333/138579994-a5d24bdc-f8c9-49ed-bcf6-207447e097d3.png">
