### PR TITLE
Fix #181 - Remove context menu links wher user logs out

### DIFF
--- a/src/js/add_input_icon.js
+++ b/src/js/add_input_icon.js
@@ -286,7 +286,6 @@ async function addRelayIconToInput(emailInput) {
 
     // Free user (who once was premium): Set text informing them how they have exceeded the maximum amount of aliases and cannot create any more
     if (numAliasesRemaining < 0) {
-      console.log("too many for free");
       remainingAliasesSpan.textContent = browser.i18n.getMessage(
         "pageFillRelayAddressLimit"
       );

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -270,7 +270,7 @@ async function createUpgradeContextMenuItem() {
   });
 }
 
-async function removeUpgradeContextMenuItem() {
+function removeUpgradeContextMenuItem() {
   browser.menus.remove("fx-private-relay-get-unlimited-aliases");
 }
 
@@ -284,13 +284,13 @@ async function updateUpgradeContextMenuItem() {
   if (premiumFeaturesAvailable(premiumEnabledString)) {
     if (!premium) {
       // Remove any previous upgrade menu items first!
-      await removeUpgradeContextMenuItem();
+      removeUpgradeContextMenuItem();
       await createUpgradeContextMenuItem();
     }
 
     // Remove the upgrade item, if the user is upgraded
     else {
-      await removeUpgradeContextMenuItem();
+      removeUpgradeContextMenuItem();
     }
   }
 }


### PR DESCRIPTION
This PR fixes #181 (and #180) 

## Testing steps: 

**Test Case 1: Context Menu Links (#181)**
1. Log in with account that is:
    - Test Case A: Non premium and has at least one alias available to generate 
    - Test Case B: Non premium and has no aliases available to generate (Maxed out) 
    - Test Case C: Premium account
2. Go to website (Example: https://imgur.com/signin) 
3. Right click on email input field (Not the relay icon)
4. **Expected:** There should be at least one menu item from Private Relay
    - Test Case A: Two menu items: Generate new alias, Get unlimited aliases
    - Test Case B: One menu item: Get unlimited aliases
    - Test Case C: One menu item: Generate new alias
5. Log out
6. Go back to test page, right click on email input again
7. **Expected:** There should be no Relay-related menu items
 
**Test Case 2: In-page Icon/Panel Links (#180)**
1. Log in with any account
2. Go to website (Example: https://imgur.com/signin) 
3. Click on Relay Icon 
4. **Expected:** Panel opens up with prompts to either generate alias or upgrade (based on your account) 
5. Log out
6. Go back to test page 
7. Click on Relay Icon 
8. **Expected:** Panel opens up with prompt to login

Preview: 
Test Case 1: Expected Test Case A Result: 
<img width="463" alt="image" src="https://user-images.githubusercontent.com/2692333/138760505-730d9726-cbd6-4ab5-b4ad-c010b99e11c1.png">

Test Case 2: Login Prompt:
<img width="385" alt="image" src="https://user-images.githubusercontent.com/2692333/138760991-a790ed19-c813-41c2-8c09-4cd30238db96.png">
