### PR TITLE
Revise upgrade CTA in alias count panel to be hidden by default

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -277,15 +277,15 @@ function removeUpgradeContextMenuItem() {
 async function updateUpgradeContextMenuItem() {
   await refreshAccountPages();
   // Check for status update
-  const premiumEnabled = await browser.storage.local.get("premiumEnabled");
-  const premiumEnabledString = premiumEnabled.premiumEnabled;
+  const { premiumEnabled } = await browser.storage.local.get("premiumEnabled");
   const { premium } = await browser.storage.local.get("premium");
 
-  if (premiumFeaturesAvailable(premiumEnabledString)) {
+  if (premiumFeaturesAvailable(premiumEnabled)) {
     if (!premium) {
       // Remove any previous upgrade menu items first!
       removeUpgradeContextMenuItem();
       await createUpgradeContextMenuItem();
+      return;
     }
 
     // Remove the upgrade item, if the user is upgraded

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -255,9 +255,9 @@ async function showRelayPanel(tipPanelToShow) {
 
 
     //If Premium features are not available, do not show upgrade CTA on the panel
-    if (!premiumFeaturesAvailable(premiumEnabledString)) {
+    if (premiumFeaturesAvailable(premiumEnabledString)) {
       const premiumCTA = document.querySelector(".premium-cta");
-      premiumCTA.classList.add("is-hidden");
+      premiumCTA.classList.remove("is-hidden");
     }
 
     // Remove panel status if user has unlimited aliases, so no negative alias left count
@@ -304,8 +304,11 @@ async function showRelayPanel(tipPanelToShow) {
   });
 
   if (premium) {
-    remainingAliasMessage.classList.add("hidden");
-    getUnlimitedAliases.classList.add("hidden");
+    remainingAliasMessage.classList.add("is-hidden");
+  }
+
+  if (premiumFeaturesAvailable(premiumEnabledString)) {
+    getUnlimitedAliases.classList.remove("is-hidden");
   }
 
   const relayPanel = document.querySelector(".signed-in-panel");

--- a/src/popup.html
+++ b/src/popup.html
@@ -51,7 +51,7 @@
         <span class="panel-status">
           <p class="aliases-remaining remaining-plural"></p>
           <a 
-            class="premium-cta i18n-content close-popup-after-click button get-premium-link" 
+            class="premium-cta i18n-content close-popup-after-click button get-premium-link is-hidden" 
             data-event-action="click"
             data-i18n-message-id="popupGetUnlimitedAliases"
             >


### PR DESCRIPTION
Fixes [MPP-1264](https://mozilla-hub.atlassian.net/browse/MPP-1264)

## Testing steps

Test Case: `PREMIUM_ENABLED=False`

1. Local website build is `PREMIUM_ENABLED=False`
2. Sign in with non-premium account
3. Click on pop-up panel
4. **Expected:** Label Sync Opt-in Panel should NOT have "Get Unlimited" CTA in top right corner

Test Case: `PREMIUM_ENABLED=True`
1. Local website build is `PREMIUM_ENABLED=True`
2. Sign in with non-premium account
3. Click on pop-up panel
4. **Expected:** Label Sync Opt-in Panel should have "Get Unlimited" CTA in top right corner

Preview: 

Test Case: `PREMIUM_ENABLED=True`: 
<img width="393" alt="image" src="https://user-images.githubusercontent.com/2692333/138765424-090af270-b4c1-4eaa-bc08-54a1ca7155f8.png">

