### PR TITLE
Localise the disallowed characters error

### DIFF
--- a/src/js/get_profile_data.js
+++ b/src/js/get_profile_data.js
@@ -281,10 +281,10 @@
       };
 
       const pluralSingularErrorMessage = (badCharactersInValue) => {
-        const newErrorMessage =
-          badCharactersInValue.length === 1
-            ? `${badCharactersInValue} is not an allowed character`
-            : `${badCharactersInValue.join(" ")} are not allowed characters`;
+        const newErrorMessage = browser.i18n.getMessage(
+          "profilePageInvalidAliasCharactersError",
+          Array.isArray(badCharactersInValue) ? badCharactersInValue.join(" ") : badCharactersInValue,
+        );
         return newErrorMessage;
       };
 


### PR DESCRIPTION
L10n dependency: https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n/pull/12

Fixes ~#1196~ #196 _(Transferred issue from website repo)_ 

Note that I changed the wording, since WebExtension i18n doesn't really allow for proper pluralisation as far as I'm aware.