### PR TITLE
Publish stage extension as artifact

### DIFF
--- a/.github/workflows/sign-and-release-to-github.yml
+++ b/.github/workflows/sign-and-release-to-github.yml
@@ -52,11 +52,30 @@ jobs:
         id: release_notes
         run: echo ::set-output name=release_notes::$(git log --no-merges --pretty=format:"%h %s" ${{ steps.version.outputs.version }}^..${{ steps.version.outputs.version }})
 
-      - name: "Release"
-        uses: softprops/action-gh-release@v1
-        with:
-          files: ./web-ext-artifacts/firefox_relay-${{ steps.version.outputs.version }}-an+fx.xpi
-          fail_on_unmatched_files: true
-          prerelease: true
-          tag_name: ${{ steps.version.outputs.version }}
-          body: ${{ steps.release_notes.outputs.release_notes }}
+      ## This should theoretically be enough to publish the extension as a GitHub Release,
+      ## except for sending the actual .xpi in the body of a request using octokit/request-action.
+      ## Left in as documentation in case someone wants to finish this up:
+      # - name: "Release"
+      #   id: create_release
+      #   uses: octokit/request-action@v2.1.0
+      #   with:
+      #     route: POST /repos/{owner}/{repo}/releases
+      #     owner: mozilla
+      #     repo: fx-private-relay-add-on
+      #     prerelease: true
+      #     tag_name: ${{ steps.version.outputs.version }}
+      #     body: ${{ steps.release_notes.outputs.release_notes }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: "Upload extension"
+      #   uses: octokit/request-action@v2.1.0
+      #   with:
+      #     route: POST /repos/{owner}/{repo}/releases/{release_id}/assets
+      #     owner: mozilla
+      #     repo: fx-private-relay-add-on
+      #     release_id: ${{ fromJson(steps.create_release.outputs.data).id }}
+      #     body: # TODO: Figure out how to pass the binary data of
+      #           #       ./web-ext-artifacts/firefox_relay-${{ steps.version.outputs.version }}-an+fx.xpi
+      #           #       here.
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sign-and-release-to-github.yml
+++ b/.github/workflows/sign-and-release-to-github.yml
@@ -52,6 +52,12 @@ jobs:
         id: release_notes
         run: echo ::set-output name=release_notes::$(git log --no-merges --pretty=format:"%h %s" ${{ steps.version.outputs.version }}^..${{ steps.version.outputs.version }})
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: fx-private-relay-stage.xpi
+          path: web-ext-artifacts/firefox_relay-${{ steps.version.outputs.version }}-an+fx.xpi
+
+
       ## This should theoretically be enough to publish the extension as a GitHub Release,
       ## except for sending the actual .xpi in the body of a request using octokit/request-action.
       ## Left in as documentation in case someone wants to finish this up:


### PR DESCRIPTION
Although not an actual GitHub release (first steps towards that added in b130d7e), this at least makes the built stage extension available for download, so people don't have to run the steps themselves.

For an example, see https://github.com/mozilla/fx-private-relay-add-on/actions/runs/1386304980.