### PR TITLE
Don't show Premium upgrade prompt when Premium

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -235,7 +235,7 @@ async function choosePanel(numRemaining, panelId, premium, premiumEnabledString,
   const shouldShowServerStoragePromptPanel = await serverStoragePanel.isRelevant();
 
   if (shouldShowPrivacyNoticeUpdatePanel) {
-    privacyNoticeUpdatePanel.init();
+    privacyNoticeUpdatePanel.init(premium);
   } else if (shouldShowServerStoragePromptPanel) {
     serverStoragePanel.init(premium);
   } else if (premium && premiumFeaturesAvailable(premiumEnabledString)) {


### PR DESCRIPTION
Fixes #203.

Makes sure the "Get unlimited aliases" prompt is not shown if the current user already has Premium:

![image](https://user-images.githubusercontent.com/4251/140929405-6c276be0-130f-486b-b50a-94f874063433.png)

Compared to before:

![image](https://user-images.githubusercontent.com/4251/140929526-445b5223-81d1-4b6f-bc01-40bd23d2ce1e.png)
