### PR TITLE
Resize Popup Panel Images for Localized Strings

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -291,6 +291,7 @@ main-panel {
   margin: 0;
   font-family: 'InterUI';
   background: white;
+  text-align: start;
 }
 
 .premium-cta {
@@ -388,15 +389,19 @@ onboarding-panel {
   display: none;
 }
 
-.content-wrapper, .premium-wrapper {
+
+.content-wrapper {
   display: flex;
-  height: 100%;
+  height: 300px;
   width: 100%;
   flex-direction: column;
+  justify-content: space-around;
 }
 
 .premium-wrapper {
   width: 100%;
+  flex-direction: column;
+  display: flex;
 }
 
 .premium-dashboard {
@@ -464,24 +469,25 @@ onboarding-panel {
 
 .email-domain-illustration {
   margin: 0 auto;
-  padding-top: 16px;
   display: block;
-  width: 280px;
 }
 
 .register-domain-component {
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  height: 250px;
 }
 
 .register-domain-cta {
-  margin: 16px auto;
   max-width: 200px;
+  text-align: center;
 }
 
 .register-domain-headline {
-  margin: 24px auto 16px auto;
   font-weight: 700;
   font-size: 14px;
+  text-align: center;
 }
 
 .educational-component {
@@ -511,13 +517,17 @@ onboarding-panel p {
   margin: 0 0 8px 0;
 }
 
-.onboarding-img {
-  padding: 16px;
+.onboarding-img, .email-domain-illustration, .education-img {
+  max-width: 100%;
+  max-height: 100%;
 }
 
-.maxAliasesPanel .onboarding-img {
-  margin: auto;
-  max-height: 140px;
+.img-wrapper {
+  margin-top: 16px;
+  max-height: 100%;
+  overflow: hidden;
+  text-align: center;
+  padding: 16px;
 }
 
 .maxAliasesPanel .onboarding-pagination {

--- a/src/popup.html
+++ b/src/popup.html
@@ -60,7 +60,9 @@
         <onboarding-panel>
           <!--Non Premium Panel-->
           <div class="content-wrapper">
-            <img class="onboarding-img">
+            <div class="img-wrapper">
+              <img class="onboarding-img">
+            </div>
             <h1 class="onboarding-h1"></h1>
             <p class="onboarding-p"></p>
             <a class="upgrade-banner-wrapper is-hidden close-popup-after-click button get-premium-link" data-event-action="click">
@@ -97,7 +99,9 @@
             </div>
             <!-- Premium Dashboard-->
             <div class="register-domain-component is-hidden">
-              <img class="email-domain-illustration">
+              <div class="img-wrapper">
+                <img class="email-domain-illustration">
+              </div>
               <p class="register-domain-headline i18n-content" data-i18n-message-id="popupRegisterDomainHeadline"></p>
               <a class="register-domain-cta i18n-content button sign-in-btn blue-primary-btn close-popup-after-click" data-event-action="click" data-i18n-message-id="popupRegisterDomainButton"></a> 
             </div>


### PR DESCRIPTION
This fixes https://github.com/mozilla/fx-private-relay/issues/1363 and resizes images depending on the length of the localized strings, in order to keep the 'Manage All Aliases' CTA always visible.
