### PR TITLE
Don't ask to get Premium if that's impossible

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -288,7 +288,8 @@ main-panel {
 }
 
 .aliases-remaining {
-  margin: 0;
+  /* If the "Get unlimited aliases" prompt is hidden, this should be centered: */
+  margin: 0 auto;
   font-family: 'InterUI';
   background: white;
 }

--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -353,9 +353,11 @@ async function addRelayIconToInput(emailInput) {
     //Check if premium features are available
     const premiumEnabled = await browser.storage.local.get("premiumEnabled");
     const premiumEnabledString = premiumEnabled.premiumEnabled;
+    const premiumCountryAvailability = (await browser.storage.local.get("premiumCountries"))?.premiumCountries;
 
     if (
       !premiumFeaturesAvailable(premiumEnabledString) ||
+      premiumCountryAvailability?.premium_available_in_country !== true ||
       !maxNumAliasesReached
     ) {
       getUnlimitedAliasesBtn.remove();

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -169,7 +169,7 @@ async function choosePanel(numRemaining, panelId, premium, premiumEnabledString,
   // if (shouldShowServerStoragePromptPanel) {
   //   serverStoragePanel.init(premium);
   // } else 
-  if (premium && premiumFeaturesAvailable(premiumEnabledString)) {
+  if (premium && premiumFeaturesAvailable(premiumEnabledString) && premiumCountryAvailability?.premium_available_in_country === true) {
     document.getElementsByClassName("content-wrapper")[0].remove();
     premiumPanelWrapper.classList.remove("is-hidden");
     premiumPanelWrapper
@@ -223,6 +223,7 @@ async function showRelayPanel(tipPanelToShow) {
   //Check if premium features are available
   const premiumEnabled = await browser.storage.local.get("premiumEnabled");
   const premiumEnabledString = premiumEnabled.premiumEnabled;
+  const premiumCountryAvailability = (await browser.storage.local.get("premiumCountries"))?.premiumCountries;
 
   //Check if user is premium
   const { premium } = await browser.storage.local.get("premium");
@@ -255,7 +256,7 @@ async function showRelayPanel(tipPanelToShow) {
 
 
     //If Premium features are not available, do not show upgrade CTA on the panel
-    if (premiumFeaturesAvailable(premiumEnabledString)) {
+    if (premiumFeaturesAvailable(premiumEnabledString) && premiumCountryAvailability?.premium_available_in_country === true) {
       const premiumCTA = document.querySelector(".premium-cta");
       premiumCTA.classList.remove("is-hidden");
     }
@@ -307,7 +308,7 @@ async function showRelayPanel(tipPanelToShow) {
     remainingAliasMessage.classList.add("is-hidden");
   }
 
-  if (premiumFeaturesAvailable(premiumEnabledString)) {
+  if (premiumFeaturesAvailable(premiumEnabledString) && premiumCountryAvailability?.premium_available_in_country === true) {
     getUnlimitedAliases.classList.remove("is-hidden");
   }
 
@@ -316,7 +317,7 @@ async function showRelayPanel(tipPanelToShow) {
 
   if (numRemaining === 0) {
     
-    if (premiumFeaturesAvailable(premiumEnabledString)) {
+    if (premiumFeaturesAvailable(premiumEnabledString) && premiumCountryAvailability?.premium_available_in_country === true) {
       const upgradeButton = document.querySelector(".upgrade-banner-wrapper");
       upgradeButton.classList.remove("is-hidden");
     }


### PR DESCRIPTION
If Premium is not available in the user's country, this
makes it so they won't see suggestions to get Premium (which would
only end up in a bounce during the checkout process).

The API that lists which countries Premium is available in is only called once every seven days at most. This might mean that we only show the calls to upgrade to Premium a week after it's become available in an additional country, unless we update the extension beforehand. (/cc @groovecoder in case you've got opinions about server load.)

This depends on https://github.com/mozilla/fx-private-relay/pull/1374, so if you want to test this locally, make sure you've got that checked out for the server.