### PR TITLE
Allow add-on detection without layout shifts

### DIFF
--- a/src/css/relay-website.css
+++ b/src/css/relay-website.css
@@ -1,0 +1,9 @@
+.is-visible-with-addon {
+    display: initial;
+    visibility: visible;
+}
+
+.is-hidden-with-addon {
+    display: none;
+    visibility: collapse;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,7 +36,13 @@
         "http://127.0.0.1/**"
       ],
       "js": ["js/relay.firefox.com/installation_indicator.js"]
-
+    },
+    {
+      "matches": [
+        "http://127.0.0.1/**"
+      ],
+      "css": ["css/relay-website.css"],
+      "run_at": "document_start"
     },
     {
       "matches": [


### PR DESCRIPTION
Instead of having the website wait 500ms for the add-on to inject
data into it indicating that it is installed, this change will
allow it to simply add an `is-hidden-with-addon` class, and then
the add-on will inject CSS even before the JS is executed that will
ensure that that element is not visible (or `is-visible-with-addon`
for the inverse behaviour). This means we should no longer have
the page jump around when the "Install the add-on" banner is
displayed.

