### PR TITLE
QA Fixes for Reuse Alias Feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fx-private-relay-add-on",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fx-private-relay-add-on",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Firefox Relay",
   "main": "index.js",
   "dependencies": {

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -285,11 +285,11 @@ main-panel {
   font-size: 1rem;
   border-bottom: 1px solid var(--relayGrey20);
   border-top: 1px solid var(--relayGrey20);
+  width: 100%;
 }
 
 .aliases-remaining {
-  /* If the "Get unlimited aliases" prompt is hidden, this should be centered: */
-  margin: 0 auto;
+  margin: 0;
   font-family: 'InterUI';
   background: white;
 }

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -72,7 +72,6 @@ async function storePremiumAvailabilityInCountry() {
     },
   })
 }
-storePremiumAvailabilityInCountry();
 
 async function getServerStoragePref() {
   const { profileID } = await browser.storage.local.get("profileID");
@@ -316,4 +315,8 @@ browser.runtime.onMessage.addListener(async (m) => {
   return response;
 });
 
-displayBrowserActionBadge();
+
+(async () => {
+  await displayBrowserActionBadge();
+  await storePremiumAvailabilityInCountry();
+})();

--- a/src/js/background/context-menu.js
+++ b/src/js/background/context-menu.js
@@ -366,6 +366,11 @@ browser.menus.onClicked.addListener(async (info, tab) => {
   }
 
   if (info.menuItemId.startsWith(reuseAliasMenuIdPrefix)) {
+    sendMetricsEvent({
+      category: "Extension: Context Menu",
+      action: "click",
+      label: "context-menu-" + info.parentMenuItemId,
+    });
     await relayContextMenus.listeners.onFillInAddressWithAliasId(info, tab);
   }
 

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -163,6 +163,7 @@ const serverStoragePanel = {
 
 async function choosePanel(numRemaining, panelId, premium, premiumEnabledString, premiumSubdomainSet){
   const premiumPanelWrapper = document.querySelector(".premium-wrapper");
+  const premiumCountryAvailability = (await browser.storage.local.get("premiumCountries"))?.premiumCountries;
 
   // Turned off label sync prompt for premium release
   // const shouldShowServerStoragePromptPanel = await serverStoragePanel.isRelevant();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Firefox Relay",
-  "version": "2.1.0",
+  "version": "2.1.1",
 
   "description": "__MSG_extensionDescription__",
 


### PR DESCRIPTION
This PR fixes a few issues flagged by QA: 
- #230 
- #234

This PR also adds telemetry to click events for the reuse alias menu items (Telemetry already exists for other items in the context menu).

## Testing Steps

**For #230:** 
- Create a new account
- Click popup/panel icon
- **Expected:** The panel opens and loads correctly
- Note: CSS fix in this PR should match the provided screenshot. 
- Upgrade to account to premium (using whichever CTA preferred
- Once upgrade, click popup/panel icon
- **Expected:** The panel opens and loads correctly

**For #234:** 
- Create new account
- Go to https://www.amazon.com/ and click sign-in
- **Expected:** You can right-click the email field and the Relay context menu is visible/available. You can generate an alias in the field. The upgrade prompt should be available.
- Upgrade account
- Refresh/re-visit Amazon Sign-in Page
- **Expected:** The same menu is still available except for the prompt to upgrade

For Telemetry: 
- Setup
  - Use browser configured to standard ETP and that has DNT disabled (so GA works) 
  - Use account that has aliases created already (on specific pages) 
  - Open up about:debugging to watch network tab for the add-on
- Go to a site with an aliases generated on it
- Right-click on email field, use context menu site alias from "Use Existing Alias from this Site…"
- **Expected:** 200 POST event to `/metrics-events` in bg.js — Request label should be `context-menu-fx-private-relay-use-existing-aliases-from-this-site`
- Go to a site that does not have alias generated
- Right-click on email field, use context menu site alias from "Recent Aliases"
- **Expected:** 200 POST event to `/metrics-events` in bg.js — Request label should be `context-menu-fx-private-relay-use-existing-aliases`

## Screenshots

Note the lack of left/right padding on "Remaining aliases" span

<img width="392" alt="image" src="https://user-images.githubusercontent.com/2692333/145466908-94934b93-794a-4d62-be53-2dda9de38cd8.png">
