### PR TITLE
Fix #239 - Only flip order of alias array if synced from the server

### DIFF
--- a/src/js/background/context-menu.js
+++ b/src/js/background/context-menu.js
@@ -217,12 +217,19 @@ const relayContextMenus = {
       // Loop Through Existing Aliases
       if (opts?.createExistingAliases) {
         
+        const shouldAliasOrderBeReversed = await getServerStoragePref();
+
         const filteredAliases = opts.exisitingSite
           ? relayContextMenus.utils.getSiteSpecificAliases(
               aliases,
-              opts.currentWebsite
+              opts.currentWebsite,
+              shouldAliasOrderBeReversed
             )
-          : relayContextMenus.utils.getMostRecentAliases(aliases, opts.currentWebsite);
+          : relayContextMenus.utils.getMostRecentAliases(
+              aliases,
+              opts.currentWebsite,
+              shouldAliasOrderBeReversed
+            );
 
         // Only create the parent menu if we will create sub-items
         if (filteredAliases.length > 0) {
@@ -281,9 +288,12 @@ const relayContextMenus = {
       const { hostname } = new URL(url);
       return hostname;
     },  
-    getMostRecentAliases: (array, domain)=> {
-      // Flipped to match the same order as the dashboard
-      array.reverse();
+    getMostRecentAliases: (array, domain, shouldFlipArray)=> {
+      // Flipped to match the same order as the dashboard if synced from the server
+      if (shouldFlipArray) {
+        array.reverse();
+      }
+      
 
       // Remove any sites that match the current site (inverse of getSiteSpecificAliases())
       const filteredAliases = array.filter(alias => alias.generated_for !== domain);
@@ -291,10 +301,12 @@ const relayContextMenus = {
       // Limit to 5
       return filteredAliases.slice(0, 5);
     },
-    getSiteSpecificAliases: (array, domain)=> {
+    getSiteSpecificAliases: (array, domain, shouldFlipArray)=> {
 
-      // Flipped to match the same order as the dashboard
-      array.reverse();
+      // Flipped to match the same order as the dashboard if synced from the server
+      if (shouldFlipArray) {
+        array.reverse();
+      }
 
       const filteredAliases = array.filter(alias => alias.generated_for === domain);
 


### PR DESCRIPTION
This fixes #239 

STR: 

- Create multiple aliases in the dashboard. Name them 1-2-3 from top to bottom. 
- Go to any site, right click on email form
- **Expected:** The order should be 1,2,3 from top to bottom. 
- Go to dashboard settings > uncheck data opt-in. 
- Go back to dashboard. Confirm aliases are still named 1,2,3 (from top to bottom) 
- Go to any site, right click on email form
- **Expected:** The order should be 1,2,3 from top to bottom. 