### PR TITLE
Fix #207 - Localize Generate Alias button tooltip message

### DIFF
--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -168,7 +168,7 @@ async function addRelayIconToInput(emailInput) {
   const relayIconBtn = createElementWithClassList("button", "fx-relay-button");
   relayIconBtn.id = "fx-relay-button";
   relayIconBtn.type = "button";
-  relayIconBtn.title = "Generate new alias";
+  relayIconBtn.title = browser.i18n.getMessage("pageInputIconGenerateNewAlias");
 
   const relayIconHeight = 30;
   if (relayIconHeight > inputHeight) {


### PR DESCRIPTION
Edited hardcoded tooltip message to localized one. 

<img width="232" alt="image" src="https://user-images.githubusercontent.com/13066134/146083224-a59eb13a-c384-4a55-bf52-d6e3a70ea517.png">
