### PR TITLE
Update string paths for l10n updates

### DIFF
--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -273,7 +273,7 @@ async function addRelayIconToInput(emailInput) {
 
     // Free user: Set text informing them how many aliases they can create
     remainingAliasesSpan.textContent = browser.i18n.getMessage(
-      "popupRemainingAliases-2",
+      "popupRemainingAliases_2",
       [numAliasesRemaining, maxNumAliases]
     );
 

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -278,7 +278,7 @@ async function showRelayPanel(tipPanelToShow) {
   const { relayAddresses, maxNumAliases } = await getRemainingAliases();
   const numRemaining = maxNumAliases - relayAddresses.length;
   const remainingAliasMessage = document.querySelector(".aliases-remaining");
-  remainingAliasMessage.textContent = browser.i18n.getMessage("popupRemainingAliases-2", [numRemaining, maxNumAliases]);
+  remainingAliasMessage.textContent = browser.i18n.getMessage("popupRemainingAliases_2", [numRemaining, maxNumAliases]);
   const getUnlimitedAliases = document.querySelector(".premium-cta");
   getUnlimitedAliases.textContent = browser.i18n.getMessage("popupGetUnlimitedAliases");
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "Firefox Relay",
   "version": "2.1.1",
 
-  "description": "__MSG_extensionDescription__",
+  "description": "__MSG_extensionDescription_v1__",
 
   "default_locale": "en",
 


### PR DESCRIPTION
This PR should land at the same time/before https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n/pull/15 (Already approved) 

- Revised description to be under 132 characters
- Revise string ID to use underscore `_` instead of hyphen `-`  (Chrome compat issue) 