### PR TITLE
Create a deployment for every add-on push

### DIFF
--- a/.github/workflows/sign-and-release-to-github.yml
+++ b/.github/workflows/sign-and-release-to-github.yml
@@ -2,15 +2,53 @@ name: continuous prerelease to GitHub
 
 on:
   push:
-    branches: [ main ]
-
+    branches: [ "*" ]
   workflow_dispatch:
 
 jobs:
+  prepare-deployment:
+    runs-on: ubuntu-latest
+    outputs:
+      deployment-id: ${{ fromJson(steps.create-deployment.outputs.result).data.id }}
+    steps:
+      - name: Create GitHub Deployment
+        id: create-deployment
+        uses: actions/github-script@v5
+        with:
+          script: |
+            return await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: "review",
+              transient_environment: true,
+              auto_merge: false,
+              // The deployment runs in parallel with CI, so status checks will never have succeeded yet:
+              required_contexts: [],
+            });
+
+
   sign-tag-release:
     runs-on: ubuntu-latest
-
+    needs: [prepare-deployment]
     steps:
+      - name: Mark GitHub Deployment as in progress
+        id: start-deployment
+        uses: actions/github-script@v5
+        env:
+          DEPLOYMENT_ID: "${{ needs.prepare-deployment.outputs.deployment-id }}"
+        with:
+          script: |
+            return await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: process.env.DEPLOYMENT_ID,
+              description: "Building add-on",
+              environment: "review",
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              state: "in_progress",
+            });
+
       - name: "Checkout"
         uses: actions/checkout@v2
 
@@ -57,6 +95,38 @@ jobs:
           name: fx-private-relay-stage.xpi
           path: web-ext-artifacts/firefox_relay-${{ steps.version.outputs.version }}-an+fx.xpi
 
+      - name: Mark GitHub Deployment as successful
+        uses: actions/github-script@v5
+        with:
+          script: |
+            return await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: parseInt(process.env.DEPLOYMENT_ID, 10),
+              description: "Add-on built successfully.",
+              environment: "review",
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              state: "success",
+            });
+        env:
+          DEPLOYMENT_ID: "${{ needs.prepare-deployment.outputs.deployment-id }}"
+
+      - name: Mark GitHub Deployment as failed
+        uses: actions/github-script@v5
+        if: failure()
+        with:
+          script: |
+            return await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: parseInt(process.env.DEPLOYMENT_ID, 10),
+              description: "Build the add-on failed. Review the GitHub Actions log for more information.",
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              environment: "review",
+              state: "failure",
+            });
+        env:
+          DEPLOYMENT_ID: "${{ needs.prepare-deployment.outputs.deployment-id }}"
 
       ## This should theoretically be enough to publish the extension as a GitHub Release,
       ## except for sending the actual .xpi in the body of a request using octokit/request-action.


### PR DESCRIPTION
This creates a GitHub Deployment whenever we push. If you then create a pull request, you can see it listed under "Environments", as below. Unfortunately, it doesn't seem to be possible to link to the artifact directly, so the "View deployment" link currently links to the Workflow run overview, which lists the add-on.

What it looks like when it's in progress:

![image](https://user-images.githubusercontent.com/4251/149190267-0beea27c-a660-4ba0-90a4-e809fc8d6a64.png)

And when built:

![image](https://user-images.githubusercontent.com/4251/149194472-38627b1a-72a8-42bc-bf18-db60f95ef748.png)

The "deployed" link is to the artifact:

![image](https://user-images.githubusercontent.com/4251/149194638-ce98aed8-c69c-4f57-a530-deb3257f8503.png)

I think if additional deployments are done after the PR is created, they are listed sa events below (in a similar style to "self-assigned this 3 minutes ago").