### PR TITLE
Fix MPP-1568: All upgrade links now point to the /premium interstitial page 

### DIFF
--- a/src/js/background/context-menu.js
+++ b/src/js/background/context-menu.js
@@ -374,13 +374,8 @@ browser.contextMenus.onClicked.addListener(async (info, tab) => {
         action: "click",
         label: "context-menu-get-unlimited-aliases",
       });
-      const { fxaSubscriptionsUrl, premiumProdId, premiumPriceId } =
-        await browser.storage.local.get([
-          "fxaSubscriptionsUrl",
-          "premiumProdId",
-          "premiumPriceId",
-        ]);
-      const urlPremium = `${fxaSubscriptionsUrl}/products/${premiumProdId}?plan=${premiumPriceId}`;
+      const { relaySiteOrigin } = await browser.storage.local.get("relaySiteOrigin");
+      const urlPremium = `${relaySiteOrigin}/premium?utm_source=fx-relay-addon&utm_medium=context-menu&utm_content=get-premium-link`;
       await browser.tabs.create({ url: urlPremium });
       break;
     case "fx-private-relay-manage-aliases":

--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -323,14 +323,7 @@ async function addRelayIconToInput(emailInput) {
     });
 
     //Create "Get unlimited aliases" link
-    const { fxaSubscriptionsUrl } = await browser.storage.local.get(
-      "fxaSubscriptionsUrl"
-    );
-    const { premiumProdId } = await browser.storage.local.get("premiumProdId");
-    const { premiumPriceId } = await browser.storage.local.get(
-      "premiumPriceId"
-    );
-    getUnlimitedAliasesBtn.href = `${fxaSubscriptionsUrl}/products/${premiumProdId}?plan=${premiumPriceId}`;
+    getUnlimitedAliasesBtn.href = `${relaySiteOrigin}/premium?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=get-premium-link`;
 
     // Restrict tabbing to relay menu elements
     restrictOrRestorePageTabbing(-1);

--- a/src/js/other-websites/fill_relay_address.js
+++ b/src/js/other-websites/fill_relay_address.js
@@ -43,12 +43,7 @@ async function showModal(modalType) {
   getUnlimitedAliasesBtn.setAttribute("rel", "noopener noreferrer");
 
   //Create "Get unlimited aliases" link
-  const { fxaSubscriptionsUrl } = await browser.storage.local.get(
-    "fxaSubscriptionsUrl"
-  );
-  const { premiumProdId } = await browser.storage.local.get("premiumProdId");
-  const { premiumPriceId } = await browser.storage.local.get("premiumPriceId");
-  getUnlimitedAliasesBtn.href = `${fxaSubscriptionsUrl}/products/${premiumProdId}?plan=${premiumPriceId}`;
+  getUnlimitedAliasesBtn.href = `${relaySiteOrigin}/premium?utm_source=fx-relay-addon&utm_medium=context-menu&utm_content=get-premium-link`;
 
   modalContent.appendChild(getUnlimitedAliasesBtn);
 

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -427,9 +427,6 @@ async function popup() {
   });
   
   const { relaySiteOrigin } = await browser.storage.local.get("relaySiteOrigin");
-  const { fxaSubscriptionsUrl } = await browser.storage.local.get("fxaSubscriptionsUrl");
-  const { premiumProdId } = await browser.storage.local.get("premiumProdId");
-  const { premiumPriceId } = await browser.storage.local.get("premiumPriceId");
 
 
   document.querySelectorAll(".login-link").forEach(loginLink => {


### PR DESCRIPTION
This PR updates the "upgrade" links across the add-on. 

Testing: 
- Use account that is _not_ premium.
- Navigate to site with login.
- Alt/right click to display context menu
- Navigate to Firefox Relay section, click "Get Unlimited Aliases"
- **Expected:** It should open a new tab, pointed to /premium page  
- Click on Relay icon in email field
- Click on "Get Unlimited Aliases"
- **Expected:** It should open a new tab, pointed to /premium page 