### PR TITLE
Fix #236 / MPP-1481: Show Correct Panel based on user's premium state

### DIFF
--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -155,14 +155,13 @@ const serverStoragePanel = {
 
 async function choosePanel(numRemaining, panelId, premium, premiumSubdomainSet){
   const premiumPanelWrapper = document.querySelector(".premium-wrapper");
-  const premiumCountryAvailability = (await browser.storage.local.get("premiumCountries"))?.premiumCountries;
-
+  
   // Turned off label sync prompt for premium release
   // const shouldShowServerStoragePromptPanel = await serverStoragePanel.isRelevant();
   // if (shouldShowServerStoragePromptPanel) {
   //   serverStoragePanel.init(premium);
   // } else 
-  if (premium && premiumCountryAvailability?.premium_available_in_country === true) {
+  if (premium) {
     document.getElementsByClassName("content-wrapper")[0].remove();
     premiumPanelWrapper.classList.remove("is-hidden");
     premiumPanelWrapper


### PR DESCRIPTION
Fixes #236 and [MPP-1481](https://mozilla-hub.atlassian.net/browse/MPP-1481)

Summary: There was an issue where premium users who opened the panel would be presented with  wrong panel/content.

Fix: Removed `premiumCountryAvailability` check to show premium panel. If the user has already upgraded, we can infer their country/state is not an issue

## Testing Steps
- Have a premium account already created
- Run/open extension
- Log into premium account
- Open Panel
- **Expected:** The panel should include the stats dashboard (See screenshot)

## Screenshots

Expected panel: 
<img width="409" alt="image" src="https://user-images.githubusercontent.com/2692333/150196841-2490f425-47c4-41de-9f0f-f62a8a9c45fb.png">
