### PR TITLE
Don't keep the first run tab open when logging in

### DIFF
--- a/src/js/first-run/first-run.js
+++ b/src/js/first-run/first-run.js
@@ -17,7 +17,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     el.addEventListener("click", (e) => {
       e.preventDefault();
       sendRelayEvent("First Run", "click", e.target.dataset.eventLabel);
-      return window.open(`${relaySiteOrigin}/accounts/profile?utm_source=fx-relay-addon&utm_medium=first-run&utm_content=first-run-sign-up-btn`);
+      return document.location = `${relaySiteOrigin}/accounts/profile?utm_source=fx-relay-addon&utm_medium=first-run&utm_content=first-run-sign-up-btn`;
     });
   });
 


### PR DESCRIPTION
In the "First run" tab, if the user clicks "Sign Up / In", a new
tab used to be opened in which they could sign in. After signing
up/in, they would be redirected back to the dashboard, but in
another tab, the "first run" screen would sill be open and asking
them to sign in, which was weird. This instead starts the sign in
flow in the same tab.

(It's [been there since the beginning](https://github.com/mozilla/fx-private-relay-add-on/blame/5e1829b03b25eeda63a5b625dbd52aa875c162e4/extension/js/first-run.js#L32), so I don't think it was too conscious a decision to open in a new tab.)