### PR TITLE
Fix #260 - Fixed an error from previous code cleanup commit

### DIFF
--- a/src/js/background/context-menu.js
+++ b/src/js/background/context-menu.js
@@ -306,7 +306,7 @@ const relayContextMenus = {
     getSiteSpecificAliases: (array, domain, options = {})=> {
 
       // Flipped to match the same order as the dashboard if synced from the server
-      if (shouldAliasOrderBeReversed) {
+      if (options.shouldAliasOrderBeReversed) {
         array.reverse();
       }
 


### PR DESCRIPTION
This PR fixes #260 

Note – This feature is only available in Firefox.

## Testing Steps: 

- Log into account (regardless of free/premium)
- Go to website 
- Generate alias via right-click menu
- Close page
- Reopen page, right click on login
- **Expected:** The alias you created should be in the "Use existing alias…" menu

## Screenshot

<img width="557" alt="image" src="https://user-images.githubusercontent.com/2692333/150858920-6d8f0cb4-89df-4bfb-900e-1fec265e7832.png">
