### PR TITLE
Add check to content script to only fire when user initiated

### DIFF
--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -181,6 +181,12 @@ async function addRelayIconToInput(emailInput) {
   };
 
   relayIconBtn.addEventListener("click", async (e) => {
+    
+    if (!e.isTrusted) {
+      // The click was not user generated so ignore
+      return false;
+    } 
+
     sendInPageEvent("input-icon-clicked", "input-icon");
 
     preventDefaultBehavior(e);


### PR DESCRIPTION
Testing steps: 
- Login add-on
- Go to https://fx-relay-input-test.netlify.app/
- **Expected:** Nothing should happen
  - _This page is actively trying to interact with the in-page Relay icon. If you go to this page with the production build, it should open the Relay icon panel up._
 