### PR TITLE
HOTFIX: Update CSS to target only Relay add-on elements base font size 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fx-private-relay-add-on",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Firefox Relay",
   "main": "index.js",
   "dependencies": {},

--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -1,7 +1,3 @@
-:root, body {
-  font-size: 16px;
-}
-
 .fx-relay-first-run,
 .fx-relay-menu-wrapper,
 .fx-relay-panel,
@@ -34,6 +30,7 @@
   font-family: open-sans, sans-serif;
   -moz-osx-font-smoothing: grayscale;
   box-sizing: border-box;
+  font-size: 16px;
 }
 
 .fx-relay-menu ::-moz-focus-inner,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Firefox Relay",
-  "version": "2.2.1",
+  "version": "2.2.2",
 
   "description": "__MSG_extensionDescription_v1__",
 


### PR DESCRIPTION
Fixes #272 