### PR TITLE
Refactor Content Script to inject iframe instead of adding directly to DOM

### DIFF
--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -1,5 +1,7 @@
 .fx-relay-first-run,
 .fx-relay-menu-wrapper,
+.fx-relay-menu-iframe,
+.fx-relay-menu-body,
 .fx-relay-panel,
 .fx-relay-icon,
 .fx-relay-modal-wrapper {
@@ -33,9 +35,46 @@
   font-size: 16px;
 }
 
+.fx-relay-menu-iframe ::-moz-focus-inner,
+.fx-relay-menu-body ::-moz-focus-inner,
 .fx-relay-menu ::-moz-focus-inner,
 .fx-relay-icon ::-moz-focus-inner {
   border: 0;
+}
+
+.fx-relay-menu-body {
+  margin: 0;
+  padding: 0;
+  background: var(--relayGrey10);
+  background-color: var(--relayGrey10);
+  box-sizing: border-box;
+}
+
+.fx-relay-menu-iframe iframe { 
+  border-radius: 4px;
+  background: var(--relayGrey10);
+  background-color: var(--relayGrey10);
+}
+
+.fx-relay-menu-iframe { 
+  width: 300px;
+  min-height: 60px;
+  top: 47px;
+  right: -15px;
+  position: absolute;
+}
+
+.fx-relay-menu-iframe::before {
+  content: " ";
+  display: block;
+  position: absolute;
+  top: -7px;
+  right: 20px;
+  height: 20px;
+  width: 20px;
+  background: var(--relayGrey10);
+  z-index: -1;
+  transform: rotate(45deg);
 }
 
 .fx-relay-menu-wrapper {
@@ -141,35 +180,13 @@ button.fx-relay-modal-close-button {
 /* input icon & icon messaging */
 
 .fx-relay-menu {
-  width: 300px;
-  min-height: 60px;
-  border-radius: 4px;
-  background: var(--relayGrey10);
-  background-color: var(--relayGrey10);
   display: flex;
   flex-direction: column;
-  position: absolute;
   align-content: center;
   padding: 24px 16px 16px 16px;
-  top: 47px;
-  right: -15px;
   pointer-events: all;
   animation: fxRelayFadeIn 0.2s ease forwards;
-  box-shadow: 3px 3px 3px 3px #00000017;
   box-sizing: border-box;
-}
-
-.fx-relay-menu::before {
-  content: "";
-  display: block;
-  position: absolute;
-  top: -7px;
-  right: 20px;
-  height: 20px;
-  width: 20px;
-  background: var(--relayGrey10);
-  z-index: -1;
-  transform: rotate(45deg);
 }
 
 .fx-relay-alias-loading {

--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -54,6 +54,9 @@
   border-radius: 4px;
   background: var(--relayGrey10);
   background-color: var(--relayGrey10);
+  border: 0;
+  box-shadow: 3px 3px 3px 3px #00000017;
+  animation: fxRelayFadeIn 0.2s ease forwards;
 }
 
 .fx-relay-menu-iframe { 
@@ -73,7 +76,7 @@
   height: 20px;
   width: 20px;
   background: var(--relayGrey10);
-  z-index: -1;
+  z-index: 1;
   transform: rotate(45deg);
 }
 

--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -2,6 +2,7 @@
 .fx-relay-menu-wrapper,
 .fx-relay-menu-iframe,
 .fx-relay-menu-body,
+.fx-relay-menu,
 .fx-relay-panel,
 .fx-relay-icon,
 .fx-relay-modal-wrapper {
@@ -90,6 +91,10 @@
   width: 100%;
   z-index: 9999999999999999999999;
   background-color: rgba(0, 0, 0, 0.1);
+}
+
+.fx-relay-menu-body .is-hidden {
+  display: none;
 }
 
 .fx-relay-modal-content fx-relay-logo-wrapper {
@@ -182,7 +187,7 @@ button.fx-relay-modal-close-button {
 
 /* input icon & icon messaging */
 
-.fx-relay-menu {
+.fx-relay-menu > div {
   display: flex;
   flex-direction: column;
   align-content: center;
@@ -254,9 +259,9 @@ button.fx-relay-menu-sign-up-btn{
   justify-content: center;
   padding: 12px 24px;
   pointer-events: all;
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
+  border-radius: 4px;
   text-decoration: none;
+  cursor: pointer;
 }
 
 .fx-relay-menu-dashboard-link, .fx-relay-modal-manage-aliases {

--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -63,6 +63,7 @@
 .fx-relay-menu-iframe { 
   width: 300px;
   min-height: 60px;
+  /* The top/right positioning here is necessary to align the box correctly (offset) underneath the "triangle" directly below the in-page Relay logo */
   top: 47px;
   right: -15px;
   position: absolute;
@@ -79,6 +80,7 @@
   background: var(--relayGrey10);
   z-index: 1;
   transform: rotate(45deg);
+  animation: fxRelayFadeIn 0.2s ease forwards;
 }
 
 .fx-relay-menu-wrapper {
@@ -91,6 +93,7 @@
   width: 100%;
   z-index: 9999999999999999999999;
   background-color: rgba(0, 0, 0, 0.1);
+  animation: fxRelayFadeIn 0.2s ease forwards;
 }
 
 .fx-relay-menu-body .is-hidden {

--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -293,6 +293,10 @@ button.fx-relay-menu-generate-alias-btn {
   margin-top: 4px;
 }
 
+button.fx-relay-menu-generate-alias-btn:focus-visible, button.fx-relay-menu-generate-alias-btn:focus {
+  outline: 5px solid rgba(0, 96, 223, .44);
+}
+
 .fx-relay-menu-get-unlimited-aliases {
   border: 2px solid var(--relayBlue3);
   width: 100%;

--- a/src/inpage-panel.html
+++ b/src/inpage-panel.html
@@ -22,16 +22,16 @@
             <div class="fx-relay-alias-loading-image"><img /></div>
 
             <span class="fx-relay-menu-remaining-aliases"></span>
-            <button class="fx-relay-menu-generate-alias-btn"></button>
+            <button tabindex="0" class="fx-relay-menu-generate-alias-btn"></button>
             
-            <a class="fx-relay-menu-get-unlimited-aliases" target="_blank" rel="noopener noreferrer" href=""></a>
-            <a class="fx-relay-menu-dashboard-link" href="" target="_blank"></a>
+            <a tabindex="0" class="fx-relay-menu-get-unlimited-aliases" target="_blank" rel="noopener noreferrer" href=""></a>
+            <a tabindex="0" class="fx-relay-menu-dashboard-link" href="" target="_blank"></a>
           </div>
           
           <!-- Logged Out Content -->
           <div class="fx-content-signed-out is-hidden">
             <span class="fx-relay-menu-sign-up-message"></span>
-            <button class="fx-relay-menu-sign-up-btn"></button>
+            <button tabindex="0" class="fx-relay-menu-sign-up-btn"></button>
           </div>
         </div>
       </div>

--- a/src/inpage-panel.html
+++ b/src/inpage-panel.html
@@ -17,11 +17,23 @@
   <body class="fx-relay-menu-body">
     <div>
         <div class="fx-relay-menu">
-          <div class="fx-relay-alias-loading-image"><img /></div>
-          <span class="fx-relay-menu-remaining-aliases"></span>
-          <button class="fx-relay-menu-generate-alias-btn"></button>
-          <a class="fx-relay-menu-get-unlimited-aliases" target="_blank" rel="noopener noreferrer" href=""></a>
-          <a class="fx-relay-menu-dashboard-link" href="" target="_blank"></a>
+
+          <!-- Logged In Content -->
+          <div class="fx-content-signed-in">
+            <div class="fx-relay-alias-loading-image"><img /></div>
+
+            <span class="fx-relay-menu-remaining-aliases"></span>
+            <button class="fx-relay-menu-generate-alias-btn"></button>
+            
+            <a class="fx-relay-menu-get-unlimited-aliases" target="_blank" rel="noopener noreferrer" href=""></a>
+            <a class="fx-relay-menu-dashboard-link" href="" target="_blank"></a>
+          </div>
+          
+          <!-- Logged Out Content -->
+          <div class="fx-content-signed-out is-hidden">
+            <span class="fx-relay-menu-sign-up-message"></span>
+            <button class="fx-relay-menu-sign-up-btn"></button>
+          </div>
         </div>
       </div>
   </body>

--- a/src/inpage-panel.html
+++ b/src/inpage-panel.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8"/>
+    <title>Firefox Relay</title>
+    <link rel="stylesheet" href="/css/relay.css" />
+    <link rel="stylesheet" href = "/css/first-run.css" />
+    <script src="/js/libs/browser-polyfill.min.js"></script>
+    <script src="/js/shared/utils.js"></script>
+    <script src="/js/shared/metrics.js"></script>
+    <script src="/js/other-websites/fathom.js"></script>
+    <script src="/js/other-websites/email_detector.js"></script>
+    <!-- <script src="/js/other-websites/add_input_icon.js"></script> -->
+    <script src="/js/other-websites/inpage_menu.js"></script>
+    <script src="/js/other-websites/fill_relay_address.js"></script>
+  </head>
+  <body class="fx-relay-menu-body">
+    <div>
+        <div class="fx-relay-menu">
+          <div class="fx-relay-alias-loading-image"><img /></div>
+          <span class="fx-relay-menu-remaining-aliases"></span>
+          <button class="fx-relay-menu-generate-alias-btn"></button>
+          <a class="fx-relay-menu-get-unlimited-aliases" target="_blank" rel="noopener noreferrer" href=""></a>
+          <a class="fx-relay-menu-dashboard-link" href="" target="_blank"></a>
+        </div>
+      </div>
+  </body>
+</html>

--- a/src/inpage-panel.html
+++ b/src/inpage-panel.html
@@ -4,14 +4,10 @@
     <meta charset="utf-8"/>
     <title>Firefox Relay</title>
     <link rel="stylesheet" href="/css/relay.css" />
-    <link rel="stylesheet" href = "/css/first-run.css" />
     <script src="/js/libs/browser-polyfill.min.js"></script>
     <script src="/js/shared/utils.js"></script>
     <script src="/js/shared/metrics.js"></script>
-    <script src="/js/other-websites/fathom.js"></script>
-    <script src="/js/other-websites/email_detector.js"></script>
     <script src="/js/other-websites/inpage_menu.js"></script>
-    <script src="/js/other-websites/fill_relay_address.js"></script>
   </head>
   <body class="fx-relay-menu-body">
     <div>
@@ -25,7 +21,7 @@
             <button tabindex="0" class="fx-relay-menu-generate-alias-btn"></button>
             
             <a tabindex="0" class="fx-relay-menu-get-unlimited-aliases" target="_blank" rel="noopener noreferrer" href=""></a>
-            <a tabindex="0" class="fx-relay-menu-dashboard-link" href="" target="_blank"></a>
+            <a tabindex="0" class="fx-relay-menu-dashboard-link" target="_blank"></a>
           </div>
           
           <!-- Logged Out Content -->

--- a/src/inpage-panel.html
+++ b/src/inpage-panel.html
@@ -10,7 +10,6 @@
     <script src="/js/shared/metrics.js"></script>
     <script src="/js/other-websites/fathom.js"></script>
     <script src="/js/other-websites/email_detector.js"></script>
-    <!-- <script src="/js/other-websites/add_input_icon.js"></script> -->
     <script src="/js/other-websites/inpage_menu.js"></script>
     <script src="/js/other-websites/fill_relay_address.js"></script>
   </head>

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -74,18 +74,12 @@ async function storePremiumAvailabilityInCountry() {
 }
 
 async function getCurrentPage() {
-  // BUG: FUNCTION DOES NOT WORK AS EXPECTED
-  let querying = browser.tabs.query({active : true, lastFocusedWindow : true});
-  let hostname;
-
-  querying.then(function (tabs) {
-    var CurrTab = tabs[0];
-    const url = new URL(CurrTab.url);
-    hostname = url.hostname;
-    return hostname;
+  const [currentTab] = await browser.tabs.query({
+    active: true,
+    currentWindow: true,
   });
 
-  return hostname;
+  return currentTab;
 }
 
 async function getServerStoragePref() {
@@ -307,20 +301,17 @@ browser.runtime.onMessage.addListener(async (m, sender, sendResponse) => {
       tab2id = sender.tab.id;
       break;
     case "fillInputWithAlias":
-      chrome.tabs.sendMessage(sender.tab.id, m.message);
+      browser.tabs.sendMessage(sender.tab.id, m.message);
       break;
     case "getServerStoragePref":
       response = await getServerStoragePref();
       break;
-    case "getCurrentPage":
-      response = await getCurrentPage();
-      sendResponse({url: response});
+    case "getCurrentPageHostname":
+      const currentPage = await getCurrentPage();
+      const url = new URL(currentPage.url);
+      response = url.hostname;
       break;
     case "makeRelayAddress":
-      // BUG: getCurrentPage DOES NOT WORK AS INTENDED
-      if (!m.description) {
-        m.description = await getCurrentPage();
-      }
       response = await makeRelayAddress(m.description);
       break;
     case "openRelayHomepage":

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -291,7 +291,6 @@ async function displayBrowserActionBadge() {
 
 browser.runtime.onMessage.addListener(async (m, sender, sendResponse) => {
   let response;
-  let tab2id;
 
   switch (m.method) {
     case "displayBrowserActionBadge":
@@ -299,9 +298,6 @@ browser.runtime.onMessage.addListener(async (m, sender, sendResponse) => {
       break;
     case "iframeCloseRelayInPageMenu":
       browser.tabs.sendMessage(sender.tab.id, {message: "iframeCloseRelayInPageMenu"});
-      break;
-    case "fillInputWithAliasParentPage":
-      tab2id = sender.tab.id;
       break;
     case "fillInputWithAlias":
       browser.tabs.sendMessage(sender.tab.id, m.message);

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -297,6 +297,9 @@ browser.runtime.onMessage.addListener(async (m, sender, sendResponse) => {
     case "displayBrowserActionBadge":
       await displayBrowserActionBadge();
       break;
+    case "iframeCloseRelayInPageMenu":
+      browser.tabs.sendMessage(sender.tab.id, {message: "iframeCloseRelayInPageMenu"});
+      break;
     case "fillInputWithAliasParentPage":
       tab2id = sender.tab.id;
       break;

--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -84,7 +84,7 @@ async function isUserSignedIn() {
   return userApiToken.hasOwnProperty("apiToken");
 }
 
-function buildInpageIframe() {
+function buildInpageIframe(opts) {
   const div = createElementWithClassList(
     "div",
     "fx-relay-menu-iframe"
@@ -93,6 +93,12 @@ function buildInpageIframe() {
   iframe.src = browser.runtime.getURL("inpage-panel.html");
   iframe.width = 300;
   iframe.height = 205;
+
+  if (!opts.isSignedIn) {
+    // If the user is not signed in, the content is shorter. Build the iframe accordingly.
+    iframe.height = 150;
+  }
+
   iframe.dataset.something = "test";
   // iframe.sandbox = ["allow-scripts"];
   // iframe.scrolling = "no";
@@ -206,7 +212,9 @@ async function addRelayIconToInput(emailInput) {
     window.addEventListener("scroll", positionRelayMenu);
     document.addEventListener("keydown", handleKeydownEvents);
 
-    const relayInPageMenu = buildInpageIframe();
+    const signedInUser = await isUserSignedIn();
+
+    const relayInPageMenu = buildInpageIframe({isSignedIn: signedInUser});
     const relayMenuWrapper = createElementWithClassList(
       "div",
       "fx-relay-menu-wrapper"
@@ -220,11 +228,10 @@ async function addRelayIconToInput(emailInput) {
 
     // Close menu if it's already open
     relayIconBtn.classList.toggle("fx-relay-menu-open");
+
     if (!relayIconBtn.classList.contains("fx-relay-menu-open")) {
       return closeRelayInPageMenu();
     }
-
-    const signedInUser = await isUserSignedIn();
 
     if (!signedInUser) {
       addRelayMenuToPage(relayMenuWrapper, relayInPageMenu, relayIconBtn);

--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -1,8 +1,8 @@
 function closeRelayInPageMenu() {
   const relayIconBtn = document.querySelector(".fx-relay-menu-open");
-  relayIconBtn.classList.remove("fx-relay-menu-open");
+  relayIconBtn?.classList.remove("fx-relay-menu-open");
   const openMenuEl = document.querySelector(".fx-relay-menu-wrapper");
-  openMenuEl.remove();
+  openMenuEl?.remove();
   restrictOrRestorePageTabbing(0);
   document.removeEventListener("keydown", handleKeydownEvents);
   window.removeEventListener("resize", positionRelayMenu);
@@ -20,19 +20,8 @@ function addRelayMenuToPage(relayMenuWrapper, relayInPageMenu, relayIconBtn) {
   return;
 }
 
-function preventDefaultBehavior(clickEvt) {
-  clickEvt.stopPropagation();
-  clickEvt.stopImmediatePropagation();
-  clickEvt.preventDefault();
-  return;
-}
-
-function getRelayMenuEl() {
-  return document.querySelector(".fx-relay-menu");
-}
-
 function positionRelayMenu() {
-  const relayInPageMenu = getRelayMenuEl();
+  const relayInPageMenu = document.querySelector(".fx-relay-menu-iframe");
   const relayIconBtn = document.querySelector(".fx-relay-menu-open");
   const newIconPosition = relayIconBtn.getBoundingClientRect();
   relayInPageMenu.style.left = newIconPosition.x - 255 + "px";
@@ -41,8 +30,8 @@ function positionRelayMenu() {
 
 let activeElemIndex = -1;
 function handleKeydownEvents(e) {
-  const relayInPageMenu = getRelayMenuEl();
-  const clickableElsInMenu = relayInPageMenu.querySelectorAll("button, a");
+  // TODO: Migrate to iframe
+  // const clickableElsInMenu = relayInPageMenu.querySelectorAll("button, a");
   const relayButton = document.querySelector(".fx-relay-button");
   const watchedKeys = ["Escape", "ArrowDown", "ArrowUp", "Tab"];
   const watchedKeyClicked = watchedKeys.includes(e.key);
@@ -62,9 +51,10 @@ function handleKeydownEvents(e) {
     activeElemIndex -= 1;
   }
 
-  if (clickableElsInMenu[activeElemIndex] !== undefined && watchedKeyClicked) {
-    return clickableElsInMenu[activeElemIndex].focus();
-  }
+  // TODO: Migrate to iframe
+  // if (clickableElsInMenu[activeElemIndex] !== undefined && watchedKeyClicked) {
+  //   return clickableElsInMenu[activeElemIndex].focus();
+  // }
 
   if (watchedKeyClicked) {
     activeElemIndex = -1;
@@ -94,6 +84,24 @@ async function isUserSignedIn() {
   return userApiToken.hasOwnProperty("apiToken");
 }
 
+function buildInpageIframe() {
+  const div = createElementWithClassList(
+    "div",
+    "fx-relay-menu-iframe"
+  );
+  const iframe = document.createElement("iframe");
+  iframe.src = browser.runtime.getURL("inpage-panel.html");
+  iframe.width = 300;
+  iframe.height = 205;
+  iframe.dataset.something = "test";
+  // iframe.sandbox = ["allow-scripts"];
+  // iframe.scrolling = "no";
+
+  div.appendChild(iframe);
+  
+  return div;
+}
+
 function addPaddingRight(element, paddingInPixels) {
   const computedElementStyles = getComputedStyle(element);
   const existingPaddingRight =
@@ -118,6 +126,9 @@ function addPaddingRight(element, paddingInPixels) {
     element.style.width = newWidth.toString() + "px";
   }
 }
+
+
+let lastClickedEmailInput;
 
 async function addRelayIconToInput(emailInput) {
   const { relaySiteOrigin } = await browser.storage.local.get(
@@ -185,8 +196,9 @@ async function addRelayIconToInput(emailInput) {
     if (!e.isTrusted) {
       // The click was not user generated so ignore
       return false;
-    } 
+    }
 
+    lastClickedEmailInput = emailInput;
     sendInPageEvent("input-icon-clicked", "input-icon");
 
     preventDefaultBehavior(e);
@@ -194,14 +206,14 @@ async function addRelayIconToInput(emailInput) {
     window.addEventListener("scroll", positionRelayMenu);
     document.addEventListener("keydown", handleKeydownEvents);
 
-    const relayInPageMenu = createElementWithClassList("div", "fx-relay-menu");
+    const relayInPageMenu = buildInpageIframe();
     const relayMenuWrapper = createElementWithClassList(
       "div",
       "fx-relay-menu-wrapper"
     );
 
     // Set custom fonts from the add-on
-    await setCustomFonts();
+    // await setCustomFonts();
 
     // Close menu if the user clicks outside of the menu
     relayMenuWrapper.addEventListener("click", closeRelayInPageMenu);
@@ -215,206 +227,12 @@ async function addRelayIconToInput(emailInput) {
     const signedInUser = await isUserSignedIn();
 
     if (!signedInUser) {
-      const signUpMessageEl = createElementWithClassList(
-        "span",
-        "fx-relay-menu-sign-up-message"
-      );
-      signUpMessageEl.textContent = browser.i18n.getMessage(
-        "pageInputIconSignUpText"
-      );
-
-      relayInPageMenu.appendChild(signUpMessageEl);
-      const signUpButton = createElementWithClassList(
-        "button",
-        "fx-relay-menu-sign-up-btn"
-      );
-      signUpButton.textContent = browser.i18n.getMessage(
-        "pageInputIconSignUpButton"
-      );
-
-      signUpButton.addEventListener("click", async (clickEvt) => {
-        preventDefaultBehavior(clickEvt);
-        await browser.runtime.sendMessage({
-          method: "openRelayHomepage",
-        });
-        sendInPageEvent("click", "input-menu-sign-up-btn");
-        closeRelayInPageMenu();
-      });
-      relayInPageMenu.appendChild(signUpButton);
-
       addRelayMenuToPage(relayMenuWrapper, relayInPageMenu, relayIconBtn);
       sendInPageEvent("viewed-menu", "unauthenticated-user-input-menu");
       return;
     }
 
     sendInPageEvent("viewed-menu", "authenticated-user-input-menu");
-    // Create "Generate Relay Address" button
-    const generateAliasBtn = createElementWithClassList(
-      "button",
-      "fx-relay-menu-generate-alias-btn"
-    );
-    generateAliasBtn.textContent = browser.i18n.getMessage(
-      "pageInputIconGenerateNewAlias"
-    );
-
-    // Create "Get unlimited aliases" button
-    const getUnlimitedAliasesBtn = createElementWithClassList(
-      "a",
-      "fx-relay-menu-get-unlimited-aliases"
-    );
-    getUnlimitedAliasesBtn.textContent = browser.i18n.getMessage(
-      "popupGetUnlimitedAliases"
-    );
-    getUnlimitedAliasesBtn.setAttribute("target", "_blank");
-    getUnlimitedAliasesBtn.setAttribute("rel", "noopener noreferrer");
-
-    // If the user has a premium accout, they may create unlimited aliases.
-    const { premium } = await browser.storage.local.get("premium");
-
-    const loadingAnimationDiv = createElementWithClassList(
-      "div",
-      "fx-relay-alias-loading-image"
-    )
-
-    const loadingAnimationImage = document.createElement("img");
-
-    loadingAnimationDiv.appendChild(loadingAnimationImage);
-
-    // Create "You have .../.. remaining relay address" message
-    const remainingAliasesSpan = createElementWithClassList(
-      "span",
-      "fx-relay-menu-remaining-aliases"
-    );
-    const { relayAddresses } = await browser.storage.local.get(
-      "relayAddresses"
-    );
-    const { maxNumAliases } = await browser.storage.local.get("maxNumAliases");
-
-    const numAliasesRemaining = maxNumAliases - relayAddresses.length;
-
-    // Free user: Set text informing them how many aliases they can create
-    remainingAliasesSpan.textContent = browser.i18n.getMessage(
-      "popupRemainingAliases_2",
-      [numAliasesRemaining, maxNumAliases]
-    );
-
-    // Free user (who once was premium): Set text informing them how they have exceeded the maximum amount of aliases and cannot create any more
-    if (numAliasesRemaining < 0) {
-      remainingAliasesSpan.textContent = browser.i18n.getMessage(
-        "pageFillRelayAddressLimit"
-      );
-    }
-
-    // Premium user: Set text informing them how many aliases they have created so far
-    if (premium) {
-      remainingAliasesSpan.textContent = browser.i18n.getMessage(
-        "popupUnlimitedAliases",
-        [relayAddresses.length]
-      );
-    }
-
-    const maxNumAliasesReached = numAliasesRemaining <= 0;
-
-    // Create "Manage All Aliases" link
-    const relayMenuDashboardLink = createElementWithClassList(
-      "a",
-      "fx-relay-menu-dashboard-link"
-    );
-    relayMenuDashboardLink.textContent =
-      browser.i18n.getMessage("ManageAllAliases");
-    relayMenuDashboardLink.href = `${relaySiteOrigin}?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=manage-all-addresses`;
-    relayMenuDashboardLink.target = "_blank";
-    relayMenuDashboardLink.addEventListener("click", () => {
-      sendInPageEvent("click", "input-menu-manage-all-aliases-btn");
-    });
-
-    //Create "Get unlimited aliases" link
-    getUnlimitedAliasesBtn.href = `${relaySiteOrigin}/premium?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=get-premium-link`;
-
-    // Restrict tabbing to relay menu elements
-    restrictOrRestorePageTabbing(-1);
-
-    // Append menu elements to the menu
-    [
-      loadingAnimationDiv,
-      remainingAliasesSpan,
-      getUnlimitedAliasesBtn,
-      generateAliasBtn,
-      relayMenuDashboardLink,
-    ].forEach((el) => {
-      relayInPageMenu.appendChild(el);
-    });
-
-    if (!premium) {
-      if (maxNumAliasesReached) {
-        generateAliasBtn.remove();
-        sendInPageEvent("viewed-menu", "input-menu-max-aliases-message");
-        remainingAliasesSpan.textContent = browser.i18n.getMessage(
-          "pageFillRelayAddressLimit",
-          [numAliasesRemaining, maxNumAliases]
-        );
-      }
-    } else {
-      getUnlimitedAliasesBtn.remove();
-    }
-
-    //Check if premium features are available
-    const premiumCountryAvailability = (await browser.storage.local.get("premiumCountries"))?.premiumCountries;
-
-    if (
-      premiumCountryAvailability?.premium_available_in_country !== true ||
-      !maxNumAliasesReached
-    ) {
-      getUnlimitedAliasesBtn.remove();
-    }
-
-    // Handle "Generate New Alias" clicks
-    generateAliasBtn.addEventListener("click", async (generateClickEvt) => {
-      sendInPageEvent("click", "input-menu-generate-alias");
-      preventDefaultBehavior(generateClickEvt);
-
-      // Attempt to create a new alias
-      const newRelayAddressResponse = await browser.runtime.sendMessage({
-        method: "makeRelayAddress",
-        description: document.location.hostname,
-      });
-      
-      const loadingImagePath = browser.runtime.getURL('/images/loader.svg');
-      document.querySelector(".fx-relay-alias-loading-image img").src = loadingImagePath;    
-
-      relayInPageMenu.classList.add("fx-relay-alias-loading");
-
-      // Catch edge cases where the "Generate New Alias" button is still enabled,
-      // but the user has already reached the max number of aliases.
-      if (newRelayAddressResponse.status === 402) {
-        relayInPageMenu.classList.remove("fx-relay-alias-loading");
-        // preserve menu height before removing child elements
-        relayInPageMenu.style.height = relayInPageMenu.clientHeight + "px";
-
-        [generateAliasBtn, remainingAliasesSpan].forEach((el) => {
-          el.remove();
-        });
-
-        const errorMessage = createElementWithClassList(
-          "p",
-          "fx-relay-error-message"
-        );
-        errorMessage.textContent = browser.i18n.getMessage(
-          "pageInputIconMaxAliasesError",
-          [relayAddresses.length]
-        );
-
-        relayInPageMenu.insertBefore(errorMessage, relayMenuDashboardLink);
-        return;
-      }
-
-      setTimeout(() => {
-        fillInputWithAlias(emailInput, newRelayAddressResponse);
-        relayIconBtn.classList.add("user-generated-relay");
-        closeRelayInPageMenu();
-      }, 700);
-    });
-
     addRelayMenuToPage(relayMenuWrapper, relayInPageMenu, relayIconBtn);
   });
 
@@ -423,20 +241,33 @@ async function addRelayIconToInput(emailInput) {
   sendInPageEvent("input-icon-injected", "input-icon");
 }
 
-function getEmailInputsAndAddIcon(domRoot) {
-  const emailInputs = detectEmailInputs(domRoot);
-  for (const emailInput of emailInputs) {
-    if (
-      !emailInput.parentElement.classList.contains(
-        "fx-relay-email-input-wrapper"
-      )
-    ) {
-      addRelayIconToInput(emailInput);
-    }
+browser.runtime.onMessage.addListener(function(m, sender, sendResponse) {
+  if (m.filter = "fillInputWithAlias") {
+    // console.log("add_input_icon/fillInputWithAlias", sender, m);
+    fillInputWithAlias(lastClickedEmailInput, m.newRelayAddressResponse);
+    const relayIconBtn = document.querySelector(".fx-relay-menu-open");
+    relayIconBtn?.classList.add("user-generated-relay");
+    closeRelayInPageMenu();
   }
-}
+});
+
+browser.runtime.sendMessage({method:"fillInputWithAliasParentPage"});
 
 (async function () {
+
+  function getEmailInputsAndAddIcon(domRoot) {
+    let emailInputs = detectEmailInputs(domRoot);
+    for (const emailInput of emailInputs) {
+      if (
+        !emailInput.parentElement.classList.contains(
+          "fx-relay-email-input-wrapper"
+        )
+      ) {
+        addRelayIconToInput(emailInput);
+      }
+    }
+  }
+
   const inputIconsAreEnabled = await areInputIconsEnabled();
   if (!inputIconsAreEnabled) {
     return;

--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -214,8 +214,6 @@ browser.runtime.onMessage.addListener(function(m, sender, sendResponse) {
   }  
 });
 
-browser.runtime.sendMessage({method:"fillInputWithAliasParentPage"});
-
 (async function () {
 
   function getEmailInputsAndAddIcon(domRoot) {

--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -243,7 +243,6 @@ async function addRelayIconToInput(emailInput) {
 
 browser.runtime.onMessage.addListener(function(m, sender, sendResponse) {
   if (m.filter = "fillInputWithAlias") {
-    // console.log("add_input_icon/fillInputWithAlias", sender, m);
     fillInputWithAlias(lastClickedEmailInput, m.newRelayAddressResponse);
     const relayIconBtn = document.querySelector(".fx-relay-menu-open");
     relayIconBtn?.classList.add("user-generated-relay");

--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -30,11 +30,11 @@ function positionRelayMenu() {
   relayInPageMenu.style.top = newIconPosition.top + 40 + "px";
 }
 
-let activeElemIndex = -1;
+// let activeElemIndex = -1;
 function handleKeydownEvents(e) {
   // TODO: Migrate to iframe
   // const clickableElsInMenu = relayInPageMenu.querySelectorAll("button, a");
-  const relayButton = document.querySelector(".fx-relay-button");
+  const relayInPageMenu = document.querySelector(".fx-relay-menu-iframe iframe");
   const watchedKeys = ["Escape", "ArrowDown", "ArrowUp", "Tab"];
   const watchedKeyClicked = watchedKeys.includes(e.key);
 
@@ -45,12 +45,12 @@ function handleKeydownEvents(e) {
 
   if (e.key === "ArrowDown" || (e.key === "Tab" && e.shiftKey === false)) {
     preventDefaultBehavior(e);
-    activeElemIndex += 1;
+    // activeElemIndex += 1;
   }
 
   if (e.key === "ArrowUp" || (e.key === "Tab" && e.shiftKey === true)) {
     preventDefaultBehavior(e);
-    activeElemIndex -= 1;
+    // activeElemIndex -= 1;
   }
 
   // TODO: Migrate to iframe
@@ -60,7 +60,7 @@ function handleKeydownEvents(e) {
 
   if (watchedKeyClicked) {
     activeElemIndex = -1;
-    relayButton.focus();
+    relayInPageMenu.contentWindow.focus();
   }
 }
 
@@ -244,7 +244,7 @@ browser.runtime.onMessage.addListener(function(m, sender, sendResponse) {
     fillInputWithAlias(lastClickedEmailInput, m.newRelayAddressResponse);
     const relayIconBtn = document.querySelector(".fx-relay-menu-open");
     relayIconBtn?.classList.add("user-generated-relay");
-    closeRelayInPageMenu();
+    return closeRelayInPageMenu();
   }
 });
 

--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -174,9 +174,6 @@ async function addRelayIconToInput(emailInput) {
       "fx-relay-menu-wrapper"
     );
 
-    // Set custom fonts from the add-on
-    // await setCustomFonts();
-
     // Close menu if the user clicks outside of the menu
     relayMenuWrapper.addEventListener("click", closeRelayInPageMenu);
 

--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -1,3 +1,5 @@
+/* global restrictOrRestorePageTabbing */
+
 function closeRelayInPageMenu() {
   const relayIconBtn = document.querySelector(".fx-relay-menu-open");
   relayIconBtn?.classList.remove("fx-relay-menu-open");
@@ -60,17 +62,6 @@ function handleKeydownEvents(e) {
     activeElemIndex = -1;
     relayButton.focus();
   }
-}
-
-// When restricting tabbing to Relay menu... tabIndexValue = -1
-// When restoring tabbing to page elements... tabIndexValue = 0
-function restrictOrRestorePageTabbing(tabIndexValue) {
-  const allClickableEls = document.querySelectorAll(
-    "button, a, input, select, option, textarea, [tabindex]"
-  );
-  allClickableEls.forEach((el) => {
-    el.tabIndex = tabIndexValue;
-  });
 }
 
 function createElementWithClassList(elemType, elemClass) {

--- a/src/js/other-websites/fill_relay_address.js
+++ b/src/js/other-websites/fill_relay_address.js
@@ -88,6 +88,8 @@ async function showModal(modalType) {
 // eslint-disable-next-line no-redeclare
 function fillInputWithAlias(emailInput, relayAlias) {
   // BUG: Duplicate fillInputWithAlias calls without proper input content
+  // The relayAlias/emailInput arguments check below is a work-around to let the duplicate call(s) fail silently. 
+  // To debug, check all instances where fillInputWithAlias() is being called and isolate it. 
   if (!emailInput || !relayAlias) {
     return false;
   }

--- a/src/js/other-websites/fill_relay_address.js
+++ b/src/js/other-websites/fill_relay_address.js
@@ -87,6 +87,12 @@ async function showModal(modalType) {
 
 // eslint-disable-next-line no-redeclare
 function fillInputWithAlias(emailInput, relayAlias) {
+
+  // BUG: Duplicate fillInputWithAlias calls without proper input contect
+  if (!emailInput) {
+    return false;
+  }
+
   switch (relayAlias.domain) {
     case 1:
       emailInput.value = relayAlias.address + "@relay.firefox.com";

--- a/src/js/other-websites/fill_relay_address.js
+++ b/src/js/other-websites/fill_relay_address.js
@@ -87,9 +87,8 @@ async function showModal(modalType) {
 
 // eslint-disable-next-line no-redeclare
 function fillInputWithAlias(emailInput, relayAlias) {
-
-  // BUG: Duplicate fillInputWithAlias calls without proper input contect
-  if (!emailInput) {
+  // BUG: Duplicate fillInputWithAlias calls without proper input content
+  if (!emailInput || !relayAlias) {
     return false;
   }
 

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -1,3 +1,5 @@
+/* global restrictOrRestorePageTabbing */
+
 function iframeCloseRelayInPageMenu() {
   // TODO: SEND MESSAGE TO CLOSE IFRAME
   // console.log("iframeCloseRelayInPageMenu");
@@ -22,17 +24,6 @@ function handleKeydownEvents(e) {
   if (clickableElsInMenu[activeElemIndex] !== undefined && watchedKeyClicked) {
     return clickableElsInMenu[activeElemIndex].focus();
   }
-}
-
-// When restricting tabbing to Relay menu... tabIndexValue = -1
-// When restoring tabbing to page elements... tabIndexValue = 0
-function restrictOrRestorePageTabbing(tabIndexValue) {
-  const allClickableEls = document.querySelectorAll(
-    "button, a, input, select, option, textarea, [tabindex]"
-  );
-  allClickableEls.forEach((el) => {
-    el.tabIndex = tabIndexValue;
-  });
 }
 
 function createElementWithClassList(elemType, elemClass) {

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -190,17 +190,13 @@ async function inpageContentInit() {
     sendInPageEvent("click", "input-menu-generate-alias");
     preventDefaultBehavior(generateClickEvt);
 
-    // In place of `document.location.hostname`
-    const currentPage = await browser.runtime.sendMessage({method: "getCurrentPage"});
-    
-    chrome.runtime.sendMessage({ method: "getCurrentPage" }, tabId => {
-      // console.log('My tabId is', tabId);
-   });
+    // Request the active tab from the background script and parse the `document.location.hostname`
+    const currentPageHostName = await browser.runtime.sendMessage({method: "getCurrentPageHostname"});
 
     // Attempt to create a new alias
     const newRelayAddressResponse = await browser.runtime.sendMessage({
       method: "makeRelayAddress",
-      description: currentPage
+      description: currentPageHostName 
     });
 
     const loadingImagePath = browser.runtime.getURL("/images/loader.svg");

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -173,10 +173,15 @@ async function inpageContentInit() {
   relayMenuDashboardLink.href = `${relaySiteOrigin}?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=manage-all-addresses`;
   relayMenuDashboardLink.addEventListener("click", () => {
     sendInPageEvent("click", "input-menu-manage-all-aliases-btn");
+    iframeCloseRelayInPageMenu();
   });
 
   // Create "Get unlimited aliases" link
   getUnlimitedAliasesBtn.href = `${relaySiteOrigin}/premium?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=get-premium-link`;
+  getUnlimitedAliasesBtn.addEventListener("click", () => {
+    sendInPageEvent("click", "input-menu-get-premium-btn");
+    iframeCloseRelayInPageMenu();
+  });
 
   if (!premium) {
     if (maxNumAliasesReached) {

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -190,6 +190,7 @@ async function inpageContentInit() {
     sendInPageEvent("click", "input-menu-generate-alias");
     preventDefaultBehavior(generateClickEvt);
 
+    // In place of `document.location.hostname`
     const currentPage = await browser.runtime.sendMessage({method: "getCurrentPage"});
     
     chrome.runtime.sendMessage({ method: "getCurrentPage" }, tabId => {
@@ -198,7 +199,8 @@ async function inpageContentInit() {
 
     // Attempt to create a new alias
     const newRelayAddressResponse = await browser.runtime.sendMessage({
-      method: "makeRelayAddress"
+      method: "makeRelayAddress",
+      description: currentPage
     });
 
     const loadingImagePath = browser.runtime.getURL("/images/loader.svg");

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -9,7 +9,7 @@ function getRelayMenuEl() {
   return document.querySelector(".fx-relay-menu");
 }
 
-let activeElemIndex = -1;
+let activeElemIndex = 0;
 function handleKeydownEvents(e) {
   const relayInPageMenu = getRelayMenuEl();
   const clickableElsInMenu = relayInPageMenu.querySelectorAll("button, a");
@@ -100,6 +100,10 @@ async function inpageContentInit() {
     });
 
     sendInPageEvent("viewed-menu", "unauthenticated-user-input-menu");
+
+    // Focus on "Go to Firefox Relay" button
+    signUpButton.focus();
+
     return;
   }
 
@@ -112,8 +116,6 @@ async function inpageContentInit() {
   const generateAliasBtn = document.querySelector(
     ".fx-relay-menu-generate-alias-btn"
   );
-
-  // generateAliasBtn.tabIndex = 0;
 
   generateAliasBtn.textContent = browser.i18n.getMessage(
     "pageInputIconGenerateNewAlias"
@@ -176,9 +178,6 @@ async function inpageContentInit() {
   // Create "Get unlimited aliases" link
   getUnlimitedAliasesBtn.href = `${relaySiteOrigin}/premium?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=get-premium-link`;
 
-  // Focus on newly opened iframe
-  generateAliasBtn.focus()
-
   if (!premium) {
     if (maxNumAliasesReached) {
       generateAliasBtn.remove();
@@ -187,8 +186,15 @@ async function inpageContentInit() {
         "pageFillRelayAddressLimit",
         [numAliasesRemaining, maxNumAliases]
       );
+      // Focus on "Get unlimited alias" button
+      getUnlimitedAliasesBtn.focus();
+    } else {
+      // Focus on "Generate New Alias" button
+      generateAliasBtn.focus();
     }
   } else {
+    // Focus on "Generate New Alias" button
+    generateAliasBtn.focus();
     getUnlimitedAliasesBtn.remove();
   }
 

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -1,13 +1,8 @@
+/* global preventDefaultBehavior */
+
 function iframeCloseRelayInPageMenu() {
   document.removeEventListener("keydown", handleKeydownEvents);
   browser.runtime.sendMessage({method:"iframeCloseRelayInPageMenu"});
-}
-
-function preventDefaultBehavior(clickEvt) {
-  clickEvt.stopPropagation();
-  clickEvt.stopImmediatePropagation();
-  clickEvt.preventDefault();
-  return;
 }
 
 function getRelayMenuEl() {
@@ -49,12 +44,6 @@ function handleKeydownEvents(e) {
   if (activeElemIndex >= clickableElsInMenu.length) {
     activeElemIndex = (clickableElsInMenu.length - 1);
   }
-}
-
-function createElementWithClassList(elemType, elemClass) {
-  const newElem = document.createElement(elemType);
-  newElem.classList.add(elemClass);
-  return newElem;
 }
 
 async function isUserSignedIn() {
@@ -251,10 +240,9 @@ async function inpageContentInit() {
         el.remove();
       });
 
-      const errorMessage = createElementWithClassList(
-        "p",
-        "fx-relay-error-message"
-      );
+      const errorMessage = document.createElement("p");
+      errorMessage.classList.add("fx-relay-error-message");
+
       errorMessage.textContent = browser.i18n.getMessage(
         "pageInputIconMaxAliasesError",
         [relayAddresses.length]
@@ -264,15 +252,13 @@ async function inpageContentInit() {
       return;
     }
 
-    setTimeout(async () => {
-      await browser.runtime.sendMessage({
-        method: "fillInputWithAlias",
-        message: {
-          filter: "fillInputWithAlias", 
-          newRelayAddressResponse
-        }
-      });
-    }, 700);
+    await browser.runtime.sendMessage({
+      method: "fillInputWithAlias",
+      message: {
+        filter: "fillInputWithAlias", 
+        newRelayAddressResponse
+      }
+    });
   });
 }
 

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -60,16 +60,23 @@ async function inpageContentInit() {
 
   const signedInUser = await isUserSignedIn();
 
+  const signedOutContent = document.querySelector(".fx-content-signed-out");
+  const signedInContent = document.querySelector(".fx-content-signed-in");
+
   if (!signedInUser) {
+    signedOutContent.classList.remove("is-hidden");
+    signedInContent.classList.add("is-hidden");
+
     const signUpMessageEl = document.querySelector(
       ".fx-relay-menu-sign-up-message"
     );
+
     signUpMessageEl.textContent = browser.i18n.getMessage(
       "pageInputIconSignUpText"
     );
 
     const signUpButton = document.querySelector(
-      ".fx-relay-menu-sign-up-message"
+      ".fx-relay-menu-sign-up-btn"
     );
 
     signUpButton.textContent = browser.i18n.getMessage(
@@ -214,6 +221,7 @@ async function inpageContentInit() {
     if (newRelayAddressResponse.status === 402) {
       relayInPageMenu.classList.remove("fx-relay-alias-loading");
       // preserve menu height before removing child elements
+      // TODO: Add background/function to adjust height of iframe
       relayInPageMenu.style.height = relayInPageMenu.clientHeight + "px";
 
       [generateAliasBtn, remainingAliasesSpan].forEach((el) => {

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -1,0 +1,252 @@
+function iframeCloseRelayInPageMenu() {
+  // TODO: SEND MESSAGE TO CLOSE IFRAME
+  // console.log("iframeCloseRelayInPageMenu");
+}
+
+function preventDefaultBehavior(clickEvt) {
+  clickEvt.stopPropagation();
+  clickEvt.stopImmediatePropagation();
+  clickEvt.preventDefault();
+  return;
+}
+
+function getRelayMenuEl() {
+  return document.querySelector(".fx-relay-menu");
+}
+
+// let activeElemIndex = -1;
+function handleKeydownEvents(e) {
+  const relayInPageMenu = getRelayMenuEl();
+  const clickableElsInMenu = relayInPageMenu.querySelectorAll("button, a");
+
+  if (clickableElsInMenu[activeElemIndex] !== undefined && watchedKeyClicked) {
+    return clickableElsInMenu[activeElemIndex].focus();
+  }
+}
+
+// When restricting tabbing to Relay menu... tabIndexValue = -1
+// When restoring tabbing to page elements... tabIndexValue = 0
+function restrictOrRestorePageTabbing(tabIndexValue) {
+  const allClickableEls = document.querySelectorAll(
+    "button, a, input, select, option, textarea, [tabindex]"
+  );
+  allClickableEls.forEach((el) => {
+    el.tabIndex = tabIndexValue;
+  });
+}
+
+function createElementWithClassList(elemType, elemClass) {
+  const newElem = document.createElement(elemType);
+  newElem.classList.add(elemClass);
+  return newElem;
+}
+
+async function isUserSignedIn() {
+  const userApiToken = await browser.storage.local.get("apiToken");
+  return userApiToken.hasOwnProperty("apiToken");
+}
+
+async function inpageContentInit() {
+  const sendInPageEvent = (evtAction, evtLabel) => {
+    sendRelayEvent("In-page", evtAction, evtLabel);
+  };
+
+  const { relaySiteOrigin } = await browser.storage.local.get(
+    "relaySiteOrigin"
+  );
+
+  // Set custom fonts from the add-on
+  await setCustomFonts();
+
+  const signedInUser = await isUserSignedIn();
+
+  if (!signedInUser) {
+    const signUpMessageEl = document.querySelector(
+      ".fx-relay-menu-sign-up-message"
+    );
+    signUpMessageEl.textContent = browser.i18n.getMessage(
+      "pageInputIconSignUpText"
+    );
+
+    const signUpButton = document.querySelector(
+      ".fx-relay-menu-sign-up-message"
+    );
+
+    signUpButton.textContent = browser.i18n.getMessage(
+      "pageInputIconSignUpButton"
+    );
+
+    signUpButton.addEventListener("click", async (clickEvt) => {
+      preventDefaultBehavior(clickEvt);
+      await browser.runtime.sendMessage({
+        method: "openRelayHomepage",
+      });
+      sendInPageEvent("click", "input-menu-sign-up-btn");
+      iframeCloseRelayInPageMenu();
+    });
+
+    sendInPageEvent("viewed-menu", "unauthenticated-user-input-menu");
+    return;
+  }
+
+  sendInPageEvent("viewed-menu", "authenticated-user-input-menu");
+  
+  // Create "Generate Relay Address" button
+  const generateAliasBtn = document.querySelector(
+    ".fx-relay-menu-generate-alias-btn"
+  );
+
+  generateAliasBtn.textContent = browser.i18n.getMessage(
+    "pageInputIconGenerateNewAlias"
+  );
+
+  // Create "Get unlimited aliases" button
+  const getUnlimitedAliasesBtn = document.querySelector(
+    ".fx-relay-menu-get-unlimited-aliases"
+  );
+  getUnlimitedAliasesBtn.textContent = browser.i18n.getMessage(
+    "popupGetUnlimitedAliases"
+  );
+
+  // If the user has a premium accout, they may create unlimited aliases.
+  const { premium } = await browser.storage.local.get("premium");
+
+  // Create "You have .../.. remaining relay address" message
+  const remainingAliasesSpan = document.querySelector(
+    ".fx-relay-menu-remaining-aliases"
+  );
+
+  const { relayAddresses } = await browser.storage.local.get("relayAddresses");
+  const { maxNumAliases } = await browser.storage.local.get("maxNumAliases");
+
+  const numAliasesRemaining = maxNumAliases - relayAddresses.length;
+
+  // Free user: Set text informing them how many aliases they can create
+  remainingAliasesSpan.textContent = browser.i18n.getMessage(
+    "popupRemainingAliases_2",
+    [numAliasesRemaining, maxNumAliases]
+  );
+
+  // Free user (who once was premium): Set text informing them how they have exceeded the maximum amount of aliases and cannot create any more
+  if (numAliasesRemaining < 0) {
+    remainingAliasesSpan.textContent = browser.i18n.getMessage(
+      "pageFillRelayAddressLimit"
+    );
+  }
+
+  // Premium user: Set text informing them how many aliases they have created so far
+  if (premium) {
+    remainingAliasesSpan.textContent = browser.i18n.getMessage(
+      "popupUnlimitedAliases",
+      [relayAddresses.length]
+    );
+  }
+
+  const maxNumAliasesReached = numAliasesRemaining <= 0;
+
+  // Create "Manage All Aliases" link
+  const relayMenuDashboardLink = document.querySelector(
+    ".fx-relay-menu-dashboard-link"
+  );
+  relayMenuDashboardLink.textContent = browser.i18n.getMessage("ManageAllAliases");
+  relayMenuDashboardLink.href = `${relaySiteOrigin}?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=manage-all-addresses`;
+  relayMenuDashboardLink.addEventListener("click", () => {
+    sendInPageEvent("click", "input-menu-manage-all-aliases-btn");
+  });
+
+  // Create "Get unlimited aliases" link
+  getUnlimitedAliasesBtn.href = `${relaySiteOrigin}/premium?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=get-premium-link`;
+
+  // Restrict tabbing to relay menu elements
+  restrictOrRestorePageTabbing(-1);
+
+  if (!premium) {
+    if (maxNumAliasesReached) {
+      generateAliasBtn.remove();
+      sendInPageEvent("viewed-menu", "input-menu-max-aliases-message");
+      remainingAliasesSpan.textContent = browser.i18n.getMessage(
+        "pageFillRelayAddressLimit",
+        [numAliasesRemaining, maxNumAliases]
+      );
+    }
+  } else {
+    getUnlimitedAliasesBtn.remove();
+  }
+
+  //Check if premium features are available
+  const premiumCountryAvailability = (
+    await browser.storage.local.get("premiumCountries")
+  )?.premiumCountries;
+
+  if (
+    premiumCountryAvailability?.premium_available_in_country !== true ||
+    !maxNumAliasesReached
+  ) {
+    getUnlimitedAliasesBtn.remove();
+  }
+
+  // Handle "Generate New Alias" clicks
+  generateAliasBtn.addEventListener("click", async (generateClickEvt) => {
+    sendInPageEvent("click", "input-menu-generate-alias");
+    preventDefaultBehavior(generateClickEvt);
+
+    const currentPage = await browser.runtime.sendMessage({method: "getCurrentPage"});
+    
+    chrome.runtime.sendMessage({ method: "getCurrentPage" }, tabId => {
+      // console.log('My tabId is', tabId);
+   });
+
+    // Attempt to create a new alias
+    const newRelayAddressResponse = await browser.runtime.sendMessage({
+      method: "makeRelayAddress"
+    });
+
+    const loadingImagePath = browser.runtime.getURL("/images/loader.svg");
+    const loadingAnimationImage = document.querySelector(
+      ".fx-relay-alias-loading-image img"
+    );
+    loadingAnimationImage.src = loadingImagePath;
+
+    const relayInPageMenu = document.querySelector(".fx-relay-menu");
+
+    relayInPageMenu.classList.add("fx-relay-alias-loading");
+
+    // Catch edge cases where the "Generate New Alias" button is still enabled,
+    // but the user has already reached the max number of aliases.
+    if (newRelayAddressResponse.status === 402) {
+      relayInPageMenu.classList.remove("fx-relay-alias-loading");
+      // preserve menu height before removing child elements
+      relayInPageMenu.style.height = relayInPageMenu.clientHeight + "px";
+
+      [generateAliasBtn, remainingAliasesSpan].forEach((el) => {
+        el.remove();
+      });
+
+      const errorMessage = createElementWithClassList(
+        "p",
+        "fx-relay-error-message"
+      );
+      errorMessage.textContent = browser.i18n.getMessage(
+        "pageInputIconMaxAliasesError",
+        [relayAddresses.length]
+      );
+
+      relayInPageMenu.insertBefore(errorMessage, relayMenuDashboardLink);
+      return;
+    }
+
+    setTimeout(async () => {
+      await browser.runtime.sendMessage({
+        method: "fillInputWithAlias",
+        message: {
+          filter: "fillInputWithAlias", 
+          newRelayAddressResponse
+        }
+      });
+    }, 700);
+  });
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
+  await inpageContentInit();
+});

--- a/src/js/shared/utils.js
+++ b/src/js/shared/utils.js
@@ -1,4 +1,4 @@
-/* exported areInputIconsEnabled setCustomFonts */
+/* exported areInputIconsEnabled setCustomFonts preventDefaultBehavior */
 
 // eslint-disable-next-line no-redeclare
 async function areInputIconsEnabled() {
@@ -30,4 +30,11 @@ async function setCustomFonts() {
     await font.load();
     document.fonts.add(font);      
   }
+}
+
+function preventDefaultBehavior(clickEvt) {
+  clickEvt.stopPropagation();
+  clickEvt.stopImmediatePropagation();
+  clickEvt.preventDefault();
+  return;
 }

--- a/src/js/shared/utils.js
+++ b/src/js/shared/utils.js
@@ -1,4 +1,4 @@
-/* exported areInputIconsEnabled setCustomFonts preventDefaultBehavior restrictOrRestorePageTabbing */
+/* exported areInputIconsEnabled setCustomFonts preventDefaultBehavior */
 
 // eslint-disable-next-line no-redeclare
 async function areInputIconsEnabled() {
@@ -37,15 +37,4 @@ function preventDefaultBehavior(clickEvt) {
   clickEvt.stopImmediatePropagation();
   clickEvt.preventDefault();
   return;
-}
-
-// When restricting tabbing to Relay menu... tabIndexValue = -1
-// When restoring tabbing to page elements... tabIndexValue = 0
-function restrictOrRestorePageTabbing(tabIndexValue) {
-  const allClickableEls = document.querySelectorAll(
-    "button, a, input, select, option, textarea, [tabindex]"
-  );
-  allClickableEls.forEach((el) => {
-    el.tabIndex = tabIndexValue;
-  });
 }

--- a/src/js/shared/utils.js
+++ b/src/js/shared/utils.js
@@ -1,4 +1,4 @@
-/* exported areInputIconsEnabled setCustomFonts preventDefaultBehavior */
+/* exported areInputIconsEnabled setCustomFonts preventDefaultBehavior restrictOrRestorePageTabbing */
 
 // eslint-disable-next-line no-redeclare
 async function areInputIconsEnabled() {
@@ -37,4 +37,15 @@ function preventDefaultBehavior(clickEvt) {
   clickEvt.stopImmediatePropagation();
   clickEvt.preventDefault();
   return;
+}
+
+// When restricting tabbing to Relay menu... tabIndexValue = -1
+// When restoring tabbing to page elements... tabIndexValue = 0
+function restrictOrRestorePageTabbing(tabIndexValue) {
+  const allClickableEls = document.querySelectorAll(
+    "button, a, input, select, option, textarea, [tabindex]"
+  );
+  allClickableEls.forEach((el) => {
+    el.tabIndex = tabIndexValue;
+  });
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,7 +15,7 @@
   "browser_specific_settings": {
       "gecko": {
           "id": "private-relay@firefox.com",
-          "strict_min_version": "63.0"
+          "strict_min_version": "74.0"
       }
   },
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -66,6 +66,7 @@
         "js/shared/utils.js",
         "js/other-websites/fathom.js",
         "js/other-websites/email_detector.js",
+        "js/other-websites/inpage_menu.js",
         "js/other-websites/add_input_icon.js",
         "js/other-websites/fill_relay_address.js",
         "js/shared/metrics.js"
@@ -87,7 +88,8 @@
     "icons/*.svg",
     "icons/*.png",
     "fonts/Inter/*.woff2",
-    "fonts/Metropolis/*.woff2"
+    "fonts/Metropolis/*.woff2",
+    "*.html"
   ]
 
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -66,7 +66,6 @@
         "js/shared/utils.js",
         "js/other-websites/fathom.js",
         "js/other-websites/email_detector.js",
-        "js/other-websites/inpage_menu.js",
         "js/other-websites/add_input_icon.js",
         "js/other-websites/fill_relay_address.js",
         "js/shared/metrics.js"


### PR DESCRIPTION
Summary: 

This PR refactors how the content script builds the in-page menu. Now, when a user clicks the icon (that appears inside an email input), an iframe is injected, serving a local page from the add-on. 

TODO: 
- [x] BUG: Resolve issue where origin domain is passed during the `newRelayAddressResponse`
- [x] BUG(S): Confirm `handleKeydownEvents` is separated correctly
- [x] BUG(S): Confirm `restrictOrRestorePageTabbing` is separated correctly
- [x] Test in both browsers
- [x] Possible issue: Focus on button when menu is open
- [ ] ~Bug: `fillInputWithAlias()` function is being called multiple times~ https://github.com/mozilla/fx-private-relay-add-on/issues/304
- [ ] Regression testing