### PR TITLE
Send browser vendor with telemetry events

### DIFF
--- a/src/js/shared/metrics.js
+++ b/src/js/shared/metrics.js
@@ -4,12 +4,14 @@
 
 // eslint-disable-next-line no-redeclare
 async function sendRelayEvent(eventCategory, eventAction, eventLabel) {
+  const browserVendor = browser.menus ? "Firefox" : "Chrome";
   return await browser.runtime.sendMessage({
     method: "sendMetricsEvent",
     eventData: {
       category: `Extension: ${eventCategory}`,
       action: eventAction,
       label: eventLabel,
+      dimension5: browserVendor
     },
   });
 }

--- a/src/js/shared/metrics.js
+++ b/src/js/shared/metrics.js
@@ -4,6 +4,8 @@
 
 // eslint-disable-next-line no-redeclare
 async function sendRelayEvent(eventCategory, eventAction, eventLabel) {
+  // "dimension5" is a Google Analytics-specific variable to track a custom dimension. 
+  // This dimension is used to determine which browser vendor the add-on is using: Firefox or Chrome
   const browserVendor = browser.menus ? "Firefox" : "Chrome";
   return await browser.runtime.sendMessage({
     method: "sendMetricsEvent",


### PR DESCRIPTION
See https://github.com/mozilla/fx-private-relay/pull/1670

This PR adds sets a custom dimension (`dimension5`) for which browser vendor the add-on uses: Firefox or Chrome. 