### PR TITLE
Don't use feature detection to detect the browser

### DIFF
--- a/src/js/shared/metrics.js
+++ b/src/js/shared/metrics.js
@@ -6,14 +6,25 @@
 async function sendRelayEvent(eventCategory, eventAction, eventLabel) {
   // "dimension5" is a Google Analytics-specific variable to track a custom dimension. 
   // This dimension is used to determine which browser vendor the add-on is using: Firefox or Chrome
-  const browserVendor = browser.menus ? "Firefox" : "Chrome";
   return await browser.runtime.sendMessage({
     method: "sendMetricsEvent",
     eventData: {
       category: `Extension: ${eventCategory}`,
       action: eventAction,
       label: eventLabel,
-      dimension5: browserVendor
+      dimension5: await getBrowser(),
     },
   });
+}
+
+async function getBrowser() {
+  if (typeof browser.runtime.getBrowserInfo === "function") {
+    /** @type {{ name: string, vendor: string, version: string, buildID: string }} */
+    const browserInfo = await browser.runtime.getBrowserInfo();
+    return browserInfo.name;
+  }
+  if (navigator.userAgent.toLowerCase().indexOf("firefox") !== -1) {
+    return "Firefox";
+  };
+  return "Chrome";
 }


### PR DESCRIPTION
If we want to know what browser the user is using, feature
detection is less reliable: if Chrome adds the browser.menus API,
all of a sudden our usage stats would be off. This was called out in AMO review.

Unfortunately Chrome also doesn't currently support the
browser.runtime.getBrowserInfo() API, so we fall back to
navigator.userAgent if needed.