### PR TITLE
Ensure the First Run shown is not shown on updates

### DIFF
--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -4,9 +4,9 @@ browser.storage.local.set({ maxNumAliases: 5 });
 browser.storage.local.set({ relaySiteOrigin: RELAY_SITE_ORIGIN });
 browser.storage.local.set({ relayApiSource: `${RELAY_SITE_ORIGIN}/api/v1` });
 
-browser.runtime.onInstalled.addListener(async () => {
+browser.runtime.onInstalled.addListener(async (details) => {
   const { firstRunShown } = await browser.storage.local.get("firstRunShown");
-  if (firstRunShown) {
+  if (firstRunShown || details.reason !== "install") {
     return;
   }
   const userApiToken = await browser.storage.local.get("apiToken");


### PR DESCRIPTION
If `firstRunShown` somehow gets removed from the user's storage,
this still avoids showing the "first run" screen when the extension
was merely updated (or one of the other non-extension-install
events [1] trigger the `onInstalled` callback.

[1] https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnInstalledReason