### PR TITLE
WIP: Refactor how the add-on detects if a user is logged into Relay or not

### DIFF
--- a/src/js/relay.firefox.com/installation_indicator.js
+++ b/src/js/relay.firefox.com/installation_indicator.js
@@ -2,45 +2,59 @@
 // updates the dataset. The Private Relay website watches for this change, and
 // makes content changes if the addon has been installed.
 
-(async () => {
-  localStorage.setItem("fxRelayAddonInstalled", "true");
-  document.querySelectorAll("firefox-private-relay-addon").forEach(async (el) => {
-    el.dataset.addonInstalled = "true";
+(async () => {  
 
-    // If server-side storage of label data is disabled, they can still be
-    // stored locally by the add-on. Here, we inject those into the website,
-    // so that it can display them in the label editor:
-    const localRandomAliasCache = (await browser.storage.local.get("relayAddresses")).relayAddresses;
-    if (Array.isArray(localRandomAliasCache)) {
-      const localLabels = localRandomAliasCache
-        .filter(address => address.description.length > 0)
-        .map(address => ({
-          type: "random",
-          id: Number.parseInt(address.id, 10),
-          description: address.description,
-          generated_for: address.generated_for,
-          address: address.address,
-        })
-      );
-      el.dataset.localLabels = JSON.stringify(localLabels);
-    }
-  });
+  let hasupdateAddOnAuthStatusRun = false;
+  
+  // BUG: Because the <firefox-private-relay-addon> dataset is initially set as false, 
+  // there's a baked-in race condition to automatically mark the user as "logged out".
+  // This setTimeout logic will only complete if the <firefox-private-relay-addon> userLoggedIn
+  // data attribute does not change from False to True, signlaing to the add-on that the user is actually logged out. 
+  // Note that this creates a different race condition between a user logging out and then closing the browser. 
+  const runUpdateAddOnAuthStatus = setTimeout( async ()=> {
+    await updateAddOnAuthStatus();
+  }, 5000);
 
-  // Check for <firefox-private-relay-addon>
-  const addonDataElement = document.querySelector(
-    "firefox-private-relay-addon"
-  );
-  if (addonDataElement) {
-    // Query if the user is logged in or out
-    const isLoggedIn = document.querySelector("firefox-private-relay-addon")
-      .dataset.userLoggedIn;
+  async function updateAddOnAuthStatus() {
 
-    if (isLoggedIn !== undefined) {
-      // As long as we get a non-undefined state, we pass it to the background script
-      await browser.runtime.sendMessage({
-        method: "updateAddOnAuthStatus",
-        status: isLoggedIn,
-      });
-    }
+    // Clear the default run() function.
+    clearTimeout(runUpdateAddOnAuthStatus);
+
+    // Catch any extra calls updateAddOnAuthStatus() after it runs once.
+    if (hasupdateAddOnAuthStatusRun) { return; }
+
+    hasupdateAddOnAuthStatusRun = true;
+    const isLoggedIn = document.querySelector("firefox-private-relay-addon").dataset.userLoggedIn;
+    await browser.runtime.sendMessage({
+      method: "updateAddOnAuthStatus",
+      status: isLoggedIn,
+    });
   }
+
+  const dahsboardInitializationObserver = new MutationObserver((mutations) => {
+    
+    // Listen to <firefox-private-relay-addon> element for dataset changes
+    mutations.forEach(async (mutation)=> {
+      if (mutation.attributeName === 'data-user-logged-in') {
+        await run();
+        dahsboardInitializationObserver.disconnect();
+      }
+    });
+  });
+  if (document.querySelector("firefox-private-relay-addon").dataset.userLoggedIn === "False") {
+    // Watch the <firefox-private-relay-addon> element if the user is not logged in
+    dahsboardInitializationObserver.observe(document.querySelector("firefox-private-relay-addon"), {
+      attributes: true, 
+      childList: false, 
+      characterData: false
+    });
+  } else {
+    await run();
+  }
+
+  // Init function
+  async function run() {
+    await updateAddOnAuthStatus();
+  }
+  
 })();


### PR DESCRIPTION
Summary: There's a few seconds (race condition) when the dashboard is page is open that sends a signal to the add-on that the user is logged out. 

Note: This PR is not the root solve for the issue, but does patch the issue some. 