### PR TITLE
More reliably track user auth status

### DIFF
--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -294,7 +294,7 @@ async function makeRelayAddress(description = null) {
 async function updateAddOnAuthStatus(status) {
   // If user is no longer logged in, remove the apiToken attribute. 
   // This will cause the "Sign in" panel to be visible when the popup is opened.
-  if (status === "False") {
+  if (status === false) {
     await browser.storage.local.remove("apiToken");
   }
 }

--- a/src/js/relay.firefox.com/get_profile_data.js
+++ b/src/js/relay.firefox.com/get_profile_data.js
@@ -319,6 +319,10 @@
     });
 
     await browser.runtime.sendMessage({
+      method: "updateAddOnAuthStatus",
+      status: true,
+    });
+    await browser.runtime.sendMessage({
       method: "rebuildContextMenuUpgrade",
     });
   }

--- a/src/js/relay.firefox.com/inject_addon_data.js
+++ b/src/js/relay.firefox.com/inject_addon_data.js
@@ -29,22 +29,4 @@
       el.dataset.localLabels = JSON.stringify(localLabels);
     }
   });
-
-  // Check for <firefox-private-relay-addon>
-  const addonDataElement = document.querySelector(
-    "firefox-private-relay-addon"
-  );
-  if (addonDataElement) {
-    // Query if the user is logged in or out
-    const isLoggedIn = document.querySelector("firefox-private-relay-addon")
-      .dataset.userLoggedIn;
-
-    if (isLoggedIn !== undefined) {
-      // As long as we get a non-undefined state, we pass it to the background script
-      await browser.runtime.sendMessage({
-        method: "updateAddOnAuthStatus",
-        status: isLoggedIn,
-      });
-    }
-  }
 })();

--- a/src/js/relay.firefox.com/track_logout.js
+++ b/src/js/relay.firefox.com/track_logout.js
@@ -1,0 +1,10 @@
+/**
+ * This function is only executed on the Relay homepage,
+ * which is only loaded when the user is not logged in - otherwise, the server
+ * will send a 302 redirect to /accounts/profile.
+ * Hence, if this script runs, we know the user is logged out.
+ */
+browser.runtime.sendMessage({
+  method: "updateAddOnAuthStatus",
+  status: false,
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -35,9 +35,15 @@
   "content_scripts": [
     {
       "matches": [
+        "http://127.0.0.1/"
+      ],
+      "js": ["js/libs/browser-polyfill.min.js", "js/relay.firefox.com/track_logout.js"]
+    },
+    {
+      "matches": [
         "http://127.0.0.1/**"
       ],
-      "js": ["js/libs/browser-polyfill.min.js", "js/relay.firefox.com/installation_indicator.js"]
+      "js": ["js/libs/browser-polyfill.min.js", "js/relay.firefox.com/inject_addon_data.js"]
     },
     {
       "matches": [


### PR DESCRIPTION
Previously, we'd detect whether the user was logged out by looking
at the `<firefox-private-relay-addon>` custom element and
inspecting its `data-user-logged-in` property. However, since the
React website checks the user's logged-in status _after_ rendering,
this could result in us concluding that the user was logged out
before it had been able to check, and logging the user out in the
add-on.

Additionally, it overloaded the API between the add-on and the
website, which has also caused a bug in the past: in addition to
the add-on injecting data into the website using attributes of
`<firefox-private-relay-addon>`, _some_ attributes were instead
used for communication the other way around, with the website
sending data to the add-on (in this case, the user's auth status).
Whereas generally, we use the `<firefox-private-relay-addon-data>`
element for communication from the website to the add-on.

With this change, we check whether the user is logged in in a
different way: if the user visits the Relay homepage (e.g. after
hitting the logout button) and does *not* get redirected to
/accounts/profile/, we can assume that they're logged out, and thus
will clear their locally-cached data.

Otherwise, if they are redirected to `/accounts/profile`, and we
were able to successfully read their data, we can conclude that
they're now logged in (so we also call `updateAddOnAuthStatus`,
although we don't actually do anything in response yet).

(Note that this does depend on https://github.com/mozilla/fx-private-relay/pull/1816 working correctly; I'm currently not seeing that work on production, even though it works on stage, and I'm [not sure why yet](https://mozilla.slack.com/archives/C013CSYEL5T/p1651846196483509).)

This solves both the bug, and makes website-add-on-communication
more consistent. When this is released, we can remove [these lines](https://github.com/mozilla/fx-private-relay/blob/8060fc4eb823de715323780c1918e8ff0a49f87c/frontend/src/pages/_app.page.tsx#L93-L97).

Fixes #314, supersedes #327.