### PR TITLE
Feature: Add "Used on Current Site" List of Masks to in-page menu

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -190,6 +190,7 @@
 .fx-relay-c-button.is-loading::after {
   content: url(/icons/button-loading.svg);
   position: absolute;
+  /* Z-index: This block overlays the button's content with a spinning circle. The z-index get's it over that content. */
   z-index: 1;
   display: block;
   animation-name: fx-relay-loader-spin;

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -102,7 +102,7 @@
 }
 
 .fx-relay-c-button {
-  display: block;
+  display: inline-block;
   padding: var(--spacingSm) var(--spacingMd);
   border-radius: var(--borderRadiusSm);
   text-align: center;

--- a/src/css/in-page.css
+++ b/src/css/in-page.css
@@ -372,7 +372,8 @@
 
 .fx-relay-menu-masks-search .fx-relay-menu-masks-list ul {
   max-height: 190px;
-  overflow: scroll;
+  overflow-y: scroll;
+  scrollbar-width: thin;
   list-style: none;
   margin: 0;
   padding: 0 0 var(--spacingSm);

--- a/src/css/in-page.css
+++ b/src/css/in-page.css
@@ -252,6 +252,7 @@
 .fx-relay-menu-masks-list button.is-loading::after {
   content: url(/icons/button-loading-dark.svg);
   position: absolute;
+  /* Z-index: This block overlays the button's content with a spinning circle. The z-index get's it over that content. */
   z-index: 1;
   display: block;
   animation-name: fx-relay-loader-spin;
@@ -262,6 +263,7 @@
   width: 24px;
   left: 50%;
   top: 50%;
+  /* This is an older centering trick, which is half of the heigh/width. transform did not work as expected. */
   margin-left: -12px;
   margin-top: -12px;
   
@@ -316,12 +318,14 @@
   cursor: pointer;
 }
 
+/* This adds a thin, vertical line seperating the two "From this website" and "All email masks" tabs. (For premium users) */
 .fx-relay-menu-filter-active-site-button + .fx-relay-menu-filter-active-site-button::after {
   content: "";
   top: 0;
   left: 0;
   width: 1px;
   height: calc(100% + var(--fxRelayMenuFilterActiveSiteButtonBorderHeight));
+  /* Z-index: Needed to appear over the tabs section */
   z-index: 1;
   background-color: var(--colorGrey20);
   position: absolute;

--- a/src/css/in-page.css
+++ b/src/css/in-page.css
@@ -141,12 +141,25 @@
   gap: var(--spacingMd);
 }
 
+/* Edge case for premium users where both "from this website" and "all mask" lists are visible at the same time */
+.fx-relay-menu-masks-list.is-visible + .fx-relay-menu-masks-list.is-visible {
+  display: none;
+}
+
 .fx-relay-menu-masks-list {
   border-radius: var(--borderRadiusSm);
   background-color: var(--colorGrey10);
   overflow: hidden;
   display: none;
 }
+
+/* .fx-relay-menu-masks-list-this-website {
+  background-color: red !important;
+}
+
+.fx-relay-menu-masks-list-all-masks {
+  background-color: blue !important;
+} */
 
 .fx-relay-menu-masks-list.is-visible {
   display: block;
@@ -302,14 +315,23 @@
   padding: var(--spacingXs) var(--spacingSm);
   margin-bottom: var(--spacingSm);
   position: relative;
+  display: none;
 }
 
-.fx-relay-menu-masks-search-results.t-no-search-bar ul {
+.fx-relay-menu-masks-search-form.is-visible {
+  display: block;
+}
+
+.fx-relay-menu-masks-search .fx-relay-menu-masks-list.t-no-search-bar ul {
   max-height: none;
   overflow: visible;
 }
 
-.fx-relay-menu-masks-search-results ul {
+.fx-relay-mask-list-toggle-height .fx-relay-menu-masks-search .fx-relay-menu-masks-list ul {
+  max-height: 140px;
+}
+
+.fx-relay-menu-masks-search .fx-relay-menu-masks-list ul {
   max-height: 190px;
   overflow: scroll;
   list-style: none;

--- a/src/css/in-page.css
+++ b/src/css/in-page.css
@@ -142,7 +142,7 @@
 }
 
 /* Edge case for premium users where both "from this website" and "all mask" lists are visible at the same time */
-.fx-relay-menu-masks-list.is-visible + .fx-relay-menu-masks-list.is-visible {
+.fx-relay-menu-masks-search .fx-relay-menu-masks-list.is-visible + .fx-relay-menu-masks-list.is-visible {
   display: none;
 }
 
@@ -152,14 +152,6 @@
   overflow: hidden;
   display: none;
 }
-
-/* .fx-relay-menu-masks-list-this-website {
-  background-color: red !important;
-}
-
-.fx-relay-menu-masks-list-all-masks {
-  background-color: blue !important;
-} */
 
 .fx-relay-menu-masks-list.is-visible {
   display: block;
@@ -230,6 +222,49 @@
   cursor: pointer;
   text-align: start;
   overflow: hidden;
+  position: relative;
+}
+
+.fx-relay-menu-masks-list button.is-loading::before {
+  position: absolute;
+  z-index: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-color: var(--colorViolet10);
+  content: "";
+  left: 0;
+  top: 0;
+  animation-name: fade-in;
+  animation-duration: 2s;
+  transition-timing-function: linear;
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.fx-relay-menu-masks-list button.is-loading::after {
+  content: url(/icons/button-loading-dark.svg);
+  position: absolute;
+  z-index: 1;
+  display: block;
+  animation-name: fx-relay-loader-spin;
+  animation-duration: 2000ms;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+  height: 24px;
+  width: 24px;
+  left: 50%;
+  top: 50%;
+  margin-left: -12px;
+  margin-top: -12px;
+  
 }
 
 .fx-relay-menu-masks-list button:hover {

--- a/src/css/in-page.css
+++ b/src/css/in-page.css
@@ -23,10 +23,13 @@
 }
 
 .is-premium .fx-relay-menu-header {
+  border: none;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.12);
   border-radius: var(--borderRadiusSm);
-  border: none;
   background-color: var(--colorWhite);
+}
+
+.is-premium .fx-relay-menu-header-logo-bar {
   position: relative;
   /* The z-index is necessary here to have the box-shadow above the rest of the content */
   z-index: 1;
@@ -39,11 +42,14 @@
 }
 
 .fx-relay-menu-header {
-  padding: var(--spacingSm);
   border-bottom: 1px solid var(--colorGrey10);
+}
+
+.fx-relay-menu-header-logo-bar {
   display: flex;
   justify-content: space-between;
   width: 100%;
+  padding: var(--spacingSm);
 }
 
 .fx-relay-menu-logo {
@@ -89,7 +95,8 @@
 }
 
 .fx-relay-menu-dashboard-link:hover .fx-relay-menu-dashboard-link-tooltip,
-.fx-relay-menu-dashboard-link:focus .fx-relay-menu-dashboard-link-tooltip {
+.fx-relay-menu-dashboard-link:focus .fx-relay-menu-dashboard-link-tooltip,
+.fx-relay-menu-dashboard-link:focus-visible .fx-relay-menu-dashboard-link-tooltip {
   display: block;
   margin: 0 var(--spacingXs);
 }
@@ -231,6 +238,54 @@
   width: 24px;
   height: 24px;
   display: inline-block;
+}
+
+/* Premium: Filter by Active Site */
+.fx-relay-menu-filter-active-site {
+  display: none;
+  overflow: hidden;
+}
+
+.fx-relay-menu-filter-active-site.is-visible {
+  display: flex;
+  width: 100%;
+  align-items: stretch;
+}
+
+.fx-relay-menu-filter-active-site-button {
+  --fxRelayMenuFilterActiveSiteButtonBorderHeight: 3px;
+  width: 50%;
+  background: transparent;
+  appearance: none;
+  outline: none;
+  border: none;
+  border-bottom: var(--fxRelayMenuFilterActiveSiteButtonBorderHeight) solid transparent;
+  color: var(--colorGrey50);
+  text-align: center;
+  padding: var(--spacingMd) 0;
+  position: relative;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.fx-relay-menu-filter-active-site-button + .fx-relay-menu-filter-active-site-button::after {
+  content: "";
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: calc(100% + var(--fxRelayMenuFilterActiveSiteButtonBorderHeight));
+  z-index: 1;
+  background-color: var(--colorGrey20);
+  position: absolute;
+}
+
+.fx-relay-menu-filter-active-site-button.is-active {
+  color: var(--colorBlue50);
+  border-bottom-color: var(--colorBlue50);
+}
+
+.fx-relay-menu-filter-active-site-button:hover, .fx-relay-menu-filter-active-site-button:focus {
+  color: var(--colorBlue50);
 }
 
 /* Premium Search List */

--- a/src/inpage-panel.html
+++ b/src/inpage-panel.html
@@ -16,25 +16,31 @@
     class="fx-relay-menu-body fx-relay is-premium is-loading"
   >
     <header class="fx-relay-menu-header">
-      <h1 class="fx-relay-menu-logo">
-        <img
-          class="fx-relay-menu-logo-image-fx-relay"
-          src="/images/logo-image-fx-relay.svg"
-          alt=""
-        />
-        <img
-          class="fx-relay-menu-logo-text"
-          alt="Firefox Relay"
-          src="/images/logo-text-fx-relay.svg"
-        />
-      </h1>
-      <a
-        class="fx-relay-menu-dashboard-link"        
-        href="http://127.0.0.1"
-      >
-        <span class="fx-relay-menu-dashboard-link-tooltip"></span>
-        <img src="/icons/nebula-external-link-blue.svg" alt="" />
-      </a>
+      <div class="fx-relay-menu-header-logo-bar">
+        <h1 class="fx-relay-menu-logo">
+          <img
+            class="fx-relay-menu-logo-image-fx-relay"
+            src="/images/logo-image-fx-relay.svg"
+            alt=""
+          />
+          <img
+            class="fx-relay-menu-logo-text"
+            alt="Firefox Relay"
+            src="/images/logo-text-fx-relay.svg"
+          />
+        </h1>
+        <a
+          class="fx-relay-menu-dashboard-link"        
+          href="http://127.0.0.1"
+        >
+          <span class="fx-relay-menu-dashboard-link-tooltip"></span>
+          <img src="/icons/nebula-external-link-blue.svg" alt="" />
+        </a>
+      </div>
+      <div class="fx-relay-menu-filter-active-site">
+        <button class="fx-relay-menu-filter-active-site-button is-active" data-string-id="labelFromThisWebsite"></button>
+        <button class="fx-relay-menu-filter-active-site-button" data-string-id="labelAllEmailMasks"></button>
+      </div>
     </header>
     <main class="fx-relay-menu">
       <div class="fx-relay-menu-loading-bar">
@@ -105,6 +111,7 @@
         ></a>
       </section>
 
+      <!-- Logged In / Premium Tier -->
       <section class="fx-relay-menu-content fx-content-signed-in-premium is-hidden">
         <div class="fx-relay-menu-masks-search">
           <form class="fx-relay-menu-masks-search-form">

--- a/src/inpage-panel.html
+++ b/src/inpage-panel.html
@@ -38,8 +38,8 @@
         </a>
       </div>
       <div class="fx-relay-menu-filter-active-site">
-        <button class="fx-relay-menu-filter-active-site-button is-active" data-string-id="labelFromThisWebsite"></button>
-        <button class="fx-relay-menu-filter-active-site-button" data-string-id="labelAllEmailMasks"></button>
+        <button class="fx-relay-menu-filter-active-site-button is-active" data-mask-list=".fx-relay-menu-masks-list-this-website" data-string-id="labelFromThisWebsite"></button>
+        <button class="fx-relay-menu-filter-active-site-button" data-mask-list=".fx-relay-menu-masks-list-all-masks"  data-string-id="labelAllEmailMasks"></button>
       </div>
     </header>
     <main class="fx-relay-menu">
@@ -127,8 +127,19 @@
               </div>
             </div>
           </form>
-          <div class="fx-relay-menu-masks-list t-search fx-relay-menu-masks-search-results is-loading">
-            <ul>
+          <div class="fx-relay-menu-masks-list t-search fx-relay-menu-masks-list-this-website is-loading">
+            <ul class="">
+              <li class="fx-relay-menu-masks-list-loading">
+                <img
+                  class="fx-relay-animation-spin"
+                  src="/icons/button-loading-dark.svg"
+                  alt=""
+                />
+              </li>
+            </ul>
+          </div>
+          <div class="fx-relay-menu-masks-list t-search fx-relay-menu-masks-list-all-masks is-loading">
+            <ul class="">
               <li class="fx-relay-menu-masks-list-loading">
                 <img
                   class="fx-relay-animation-spin"

--- a/src/inpage-panel.html
+++ b/src/inpage-panel.html
@@ -66,15 +66,18 @@
 
         <div class="fx-relay-menu-masks-lists">
           <!-- Reused Alias Menu -->
-          <!-- WIP/TODO: Markup for follow up "site used on" feature -->
-          <!-- <div class="fx-relay-menu-masks-list t-website fx-relay-menu-masks-free-this-website">
+          <div class="fx-relay-menu-masks-list t-website fx-relay-menu-masks-free-this-website">
             <span data-string-id="pageInputIconPreviouslyUsedMask" class="fx-relay-menu-masks-list-label"></span>
-            <ul>
-              <li>
-                <button >Label name</button>
+            <ul class="is-loading">
+              <li class="fx-relay-menu-masks-list-loading">
+                <img
+                  class="fx-relay-animation-spin"
+                  src="/icons/button-loading-dark.svg"
+                  alt=""
+                />
               </li>
             </ul>
-          </div> -->
+          </div>
 
           <div class="fx-relay-menu-masks-list fx-relay-menu-masks-free-other">
             <span

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -85,8 +85,6 @@ async function patchMaskInfo(method = "PATCH", id, data, opts=null) {
   }
 
   const apiRequestUrl = opts.domainAddress ? apiMakeDomainAddressesURL : apiMakeRelayAddressesURL;
-  
-  console.log(data);
 
   const response = await fetch(apiRequestUrl, {
     mode: "same-origin",

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -64,6 +64,40 @@ async function getAliasesFromServer(method = "GET", opts=null) {
   return masks;
 }
 
+// This function is defined as global in the ESLint config _because_ it is created here:
+// eslint-disable-next-line no-redeclare, no-unused-vars
+async function patchMaskInfo(method = "PATCH", id, data, opts=null) {
+
+  const { relayApiSource } = await browser.storage.local.get("relayApiSource");  
+  const apiMakeRelayAddressesURL = `${relayApiSource}/relayaddresses/${id}/`;
+  const apiMakeDomainAddressesURL = `${relayApiSource}/domainaddresses/${id}/`;
+
+  const csrfCookieValue = await browser.storage.local.get("csrfCookieValue");
+  const headers = new Headers();
+  
+  headers.set("X-CSRFToken", csrfCookieValue);
+  headers.set("Content-Type", "application/json");
+  headers.set("Accept", "application/json");
+  
+  if (opts && opts.auth) {
+    const apiToken = await browser.storage.local.get("apiToken");
+    headers.set("Authorization", `Token ${apiToken.apiToken}`);
+  }
+
+  const apiRequestUrl = opts.domainAddress ? apiMakeDomainAddressesURL : apiMakeRelayAddressesURL;
+  
+  console.log(data);
+
+  const response = await fetch(apiRequestUrl, {
+    mode: "same-origin",
+    method,
+    headers: headers,
+    body: JSON.stringify(data),
+  });
+
+  return await response.json();
+}
+
 async function storePremiumAvailabilityInCountry() {
   // If we already fetched Premium availability in the past seven days,
   // don't fetch it again.
@@ -328,6 +362,9 @@ browser.runtime.onMessage.addListener(async (m, sender, _sendResponse) => {
       break;
     case "getAliasesFromServer":
       response = await getAliasesFromServer("GET", m.options);
+      break;
+    case "patchMaskInfo":
+      await patchMaskInfo("PATCH", m.id, m.data, m.options);
       break;
     case "getCurrentPage":
       response = await getCurrentPage();

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -22,8 +22,8 @@ browser.runtime.onInstalled.addListener(async (details) => {
 // eslint-disable-next-line no-redeclare, no-unused-vars
 async function getAliasesFromServer(method = "GET", opts=null) {
   const { relayApiSource } = await browser.storage.local.get("relayApiSource");  
-  const apiMakeRelayAddressesURL = `${relayApiSource}/relayaddresses/`;
-  const apiMakeDomainAddressesURL = `${relayApiSource}/domainaddresses/`;
+  const getRelayAddressesUrl = `${relayApiSource}/relayaddresses/`;
+  const getDomainAddressesUrl = `${relayApiSource}/domainaddresses/`;
 
   const csrfCookieValue = await browser.storage.local.get("csrfCookieValue");
   const headers = new Headers();
@@ -37,7 +37,7 @@ async function getAliasesFromServer(method = "GET", opts=null) {
     headers.set("Authorization", `Token ${apiToken.apiToken}`);
   }
 
-  const response = await fetch(apiMakeRelayAddressesURL, {
+  const response = await fetch(getRelayAddressesUrl, {
     mode: "same-origin",
     method,
     headers: headers,
@@ -49,7 +49,7 @@ async function getAliasesFromServer(method = "GET", opts=null) {
 
   // If the user has domain (custom) masks set, also grab them before sorting
   if (opts.fetchCustomMasks) {
-    const domainResponse = await fetch(apiMakeDomainAddressesURL, {
+    const domainResponse = await fetch(getDomainAddressesUrl, {
       mode: "same-origin",
       method,
       headers: headers,
@@ -69,8 +69,8 @@ async function getAliasesFromServer(method = "GET", opts=null) {
 async function patchMaskInfo(method = "PATCH", id, data, opts=null) {
 
   const { relayApiSource } = await browser.storage.local.get("relayApiSource");  
-  const apiMakeRelayAddressesURL = `${relayApiSource}/relayaddresses/${id}/`;
-  const apiMakeDomainAddressesURL = `${relayApiSource}/domainaddresses/${id}/`;
+  const updateRelayAddressURL = `${relayApiSource}/relayaddresses/${id}/`;
+  const updateDomainAddressURL = `${relayApiSource}/domainaddresses/${id}/`;
 
   const csrfCookieValue = await browser.storage.local.get("csrfCookieValue");
   const headers = new Headers();
@@ -84,7 +84,7 @@ async function patchMaskInfo(method = "PATCH", id, data, opts=null) {
     headers.set("Authorization", `Token ${apiToken.apiToken}`);
   }
 
-  const apiRequestUrl = opts.domainAddress ? apiMakeDomainAddressesURL : apiMakeRelayAddressesURL;
+  const apiRequestUrl = opts.domainAddress ? updateDomainAddressURL : updateRelayAddressURL;
 
   const response = await fetch(apiRequestUrl, {
     mode: "same-origin",
@@ -243,8 +243,7 @@ async function makeRelayAddress(description = null) {
 
   const { relayApiSource } = await browser.storage.local.get("relayApiSource");  
   const serverStoragePermission = await getServerStoragePref();
-  const apiMakeRelayAddressesURL = `${relayApiSource}/relayaddresses/`;
-  const newRelayAddressUrl = apiMakeRelayAddressesURL;
+  const makeRelayAddressUrl = `${relayApiSource}/relayaddresses/`;
 
   let apiBody = {
     enabled: true,
@@ -260,7 +259,7 @@ async function makeRelayAddress(description = null) {
 
   const headers = await createNewHeadersObject({auth: true});
 
-  const newRelayAddressResponse = await fetch(newRelayAddressUrl, {
+  const newRelayAddressResponse = await fetch(makeRelayAddressUrl, {
     mode: "same-origin",
     method: "POST",
     headers: headers,

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -294,8 +294,8 @@ async function makeRelayAddress(description = null) {
   const updatedLocalRelayAddresses = localRelayAddresses.relayAddresses.concat([
     newRelayAddressJson,
   ]);
+  
   browser.storage.local.set({ relayAddresses: updatedLocalRelayAddresses });
-
   return newRelayAddressJson;
 }
 

--- a/src/js/other-websites/add_input_icon.js
+++ b/src/js/other-websites/add_input_icon.js
@@ -35,7 +35,7 @@ function positionRelayMenu() {
   const relayInPageMenuIframe = document.querySelector(".fx-relay-menu-iframe");
   const newIconPosition = relayIconBtn.getBoundingClientRect();
   const documentPosition = document.documentElement.getBoundingClientRect();
-  const RELAY_INPAGE_MENU_MAXIMUM_HEIGHT = 405
+  const RELAY_INPAGE_MENU_MAXIMUM_HEIGHT = 435
   
   // Calculate the "safe area" of add-on in-page menu. If there's not enough room to expand below the icon, it expands above. 
   // The RELAY_INPAGE_MENU_MAXIMUM_HEIGHT / 405 is the pixel height of the tallest version of the inpage menu. 

--- a/src/js/other-websites/fill_relay_address.js
+++ b/src/js/other-websites/fill_relay_address.js
@@ -7,26 +7,19 @@ function fillInputWithAlias(emailInput, relayAlias) {
     return false;
   }
 
-  switch (relayAlias.domain) {
-    case 1:
-      emailInput.value = relayAlias.address + "@relay.firefox.com";
-      break;
-    case 2:
-      emailInput.value = relayAlias.address + "@mozmail.com";
-      break;
-    default:
-      // User does not sync data so no relayAlias.domain is available
-      emailInput.value = relayAlias.address
-      break;
-  }
+  // If this is a newly created relayAlias, it will be an object with lots of info to parse. 
+  // Otherwise, it's a reused mask, so it's just the email address. 
+  const emailMask = (relayAlias.full_address) ? relayAlias.full_address : relayAlias.address
+
+  // Set the value of the target field to the selected/generated mask
+  emailInput.value = emailMask;
 
   emailInput.dispatchEvent(
     new InputEvent("relay-address", {
-      data: relayAlias.address,
+      data: emailMask,
     })
   );
 }
-
 
 // COMPATIBILITY NOTE: browser.menus.getTargetElement is not available so 
 // we have to listen for any contextmenu click to determe the target element.

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -235,6 +235,16 @@ const buildContent = {
 
       const maskLists = document.querySelectorAll(".fx-relay-menu-masks-list");
       const masks = await getMasks();
+      
+      const currentPageHostName = await browser.runtime.sendMessage({
+        method: "getCurrentPageHostname",
+      });
+
+      // function checkIfAnyMasksAreUsedOnCurrentWebsite(masks, domain) {
+      //   return masks.some( mask => {
+      //     return domain === mask.generated_for;
+      //   });
+      // }
 
       maskLists?.forEach(async (maskList) => {
         // Set Mask List label names
@@ -246,8 +256,15 @@ const buildContent = {
         label.textContent = browser.i18n.getMessage(stringId);
 
         if (masks.length > 0) {
-          // Populate mask lists
-          await populateMaskList(maskList, masks);
+          // Populate mask lists, but filter by current website
+          const buildFilteredMaskList = maskList.classList.contains("fx-relay-menu-masks-free-this-website");
+
+          // TODO: Check additional field(s) besides "generated_for"
+          const filteredMasks = buildFilteredMaskList ? 
+            masks.filter(mask => mask.generated_for === currentPageHostName)
+            : masks.filter(mask => mask.generated_for !== currentPageHostName);
+          
+          await populateMaskList(maskList, filteredMasks);
         }
       });
 

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -118,10 +118,11 @@ async function fillTargetWithRelayAddress(generateClickEvt) {
   const maskAddress = generateClickEvt.target.dataset.mask;
   const maskAddressId = generateClickEvt.target.dataset.maskId;
 
+  
   const maskObject = masks.find(
     (mask) => mask.id === parseInt(maskAddressId, 10)
-  );
-
+    );
+    
   const currentUsedOnValue = maskObject.used_on;
 
   const currentPageHostName = await browser.runtime.sendMessage({
@@ -140,6 +141,7 @@ async function fillTargetWithRelayAddress(generateClickEvt) {
     },
     options: {
       auth: true,
+      mask_type: maskObject.mask_type,
     },
   });
 

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -309,6 +309,26 @@ function hasMaskBeenUsedOnCurrentSite(mask, domain) {
   return false;
 }
 
+function haveMasksBeenUsedOnCurrentSite(masks, domain) {
+  return masks.some(mask => {
+    
+    const domainList = mask.used_on;
+
+    // Short circuit out if there's no used_on entry
+    if (domainList === null || domainList === "" ||  domainList === undefined) { return false; }
+
+    const usedOnDomains = domainList.split(",");
+
+    // Domain already exists in used_on field. Just return the list!
+    if (usedOnDomains.includes(domain)) {
+      return true;
+    }
+
+    // No match found! 
+    return false;
+  })
+}
+
 const buildContent = {
   loggedIn: {
     free: async (relaySiteOrigin) => {
@@ -483,8 +503,7 @@ const buildContent = {
       // If so, we'll end up building two discret mask lists:  
       // 1. Just masks for that specific website
       // 2. All masks (including ones from the previous list)
-      const userHasMasksForCurrentWebsite =
-        checkIfAnyMasksWereGeneratedOnCurrentWebsite(masks, currentPageHostName);
+      const userHasMasksForCurrentWebsite = (checkIfAnyMasksWereGeneratedOnCurrentWebsite(masks, currentPageHostName)) || haveMasksBeenUsedOnCurrentSite(masks, currentPageHostName);
 
       // If there are no masks assosiated with the current site, remove that list entirely.
       if (!userHasMasksForCurrentWebsite) {

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -294,13 +294,11 @@ function checkIfAnyMasksWereGeneratedOnCurrentWebsite(masks, domain) {
 
 function hasMaskBeenUsedOnCurrentSite(mask, domain) {
   const domainList = mask.used_on;
-  console.log("hasMaskBeenUsedOnCurrentSite/domainList", domainList);
 
   // Short circuit out if there's no used_on entry
   if (domainList === null || domainList === "" ||  domainList === undefined) { return false; }
 
   const usedOnDomains = domainList.split(",");
-  console.log("usedOnDomains", usedOnDomains);
 
   // Domain already exists in used_on field. Just return the list!
   if (usedOnDomains.includes(domain)) {
@@ -360,8 +358,6 @@ const buildContent = {
           label.textContent = "Select from your current email masks";
         }
 
-        console.log("masks", masks);
-
         if (masks.length > 0) {
           // Populate mask lists, but filter by current website
           const buildFilteredMaskList = maskList.classList.contains(
@@ -376,9 +372,6 @@ const buildContent = {
             : masks.filter(
               (mask) => mask.generated_for !== currentPageHostName && !hasMaskBeenUsedOnCurrentSite(mask, currentPageHostName)
               );
-          
-          console.log("filteredMasks", filteredMasks);
-              
 
           await populateFreeMaskList(maskList, filteredMasks);
         }
@@ -407,9 +400,20 @@ const buildContent = {
           "pageNoMasksRemaining"
         );
 
+        // Check if premium features are available
+        const premiumCountryAvailability = (
+          await browser.storage.local.get("premiumCountries")
+        )?.premiumCountries;
+
         const getUnlimitedAliasesBtn = document.querySelector(
           ".fx-relay-menu-get-unlimited-aliases"
         );
+
+        // If the user cannot upgrade, prompt them to join the waitlist
+        if ( premiumCountryAvailability?.premium_available_in_country !== true ) {
+          getUnlimitedAliasesBtn.textContent = browser.i18n.getMessage("pageInputIconJoinPremiumWaitlist");
+          // TODO: (?) Change URL to waitlist page, adjust telemetry to measure 
+        }
 
         getUnlimitedAliasesBtn.classList.remove("t-secondary");
         getUnlimitedAliasesBtn.classList.add("t-primary");
@@ -425,19 +429,6 @@ const buildContent = {
         // Focus on "Generate New Alias" button
         generateAliasBtn.focus();
       }
-
-      // TODO: Add premiumCountryAvailability Check
-      // Check if premium features are available
-      // const premiumCountryAvailability = (
-      //   await browser.storage.local.get("premiumCountries")
-      // )?.premiumCountries;
-
-      // if (
-      //   premiumCountryAvailability?.premium_available_in_country !== true ||
-      //   !maxNumAliasesReached
-      // ) {
-      //   getUnlimitedAliasesBtn.remove();
-      // }
 
       fxRelayMenuBody.classList.remove("is-loading");
       // User is signed in/free: Remove the premium section from DOM so there are no hidden/screen readable-elements available

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -129,7 +129,7 @@ async function fillTargetWithRelayAddress(generateClickEvt) {
   });
 
   // If the used_on field is blank, then just set it to the current page/hostname. Otherwise, add/check if domain exists in the field
-  const used_on = (currentUsedOnValue === null) ? `${currentPageHostName},` : addUsedOnDomain(currentUsedOnValue, currentPageHostName)
+  const used_on = (currentUsedOnValue === null || currentUsedOnValue === undefined || currentUsedOnValue === "") ? `${currentPageHostName},` : addUsedOnDomain(currentUsedOnValue, currentPageHostName)
   
   // Update server info with site usage
   await browser.runtime.sendMessage({

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -240,20 +240,26 @@ const buildContent = {
         method: "getCurrentPageHostname",
       });
 
-      // function checkIfAnyMasksAreUsedOnCurrentWebsite(masks, domain) {
-      //   return masks.some( mask => {
-      //     return domain === mask.generated_for;
-      //   });
-      // }
+      function checkIfAnyMasksAreUsedOnCurrentWebsite(masks, domain) {
+        return masks.some( mask => {
+          return domain === mask.generated_for;
+        });
+      }
 
       maskLists?.forEach(async (maskList) => {
         // Set Mask List label names
-
         const label = maskList.querySelector(".fx-relay-menu-masks-list-label");        
-
         const stringId = label.dataset.stringId;
         
         label.textContent = browser.i18n.getMessage(stringId);
+
+        // If there are no masks used on the current site, we need to change the label for the other masks:
+        if (!checkIfAnyMasksAreUsedOnCurrentWebsite(masks, currentPageHostName) && maskList.classList.contains("fx-relay-menu-masks-free-other")) {
+          // TODO / BLOCKED: https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n/pull/31 
+          // needs to merge for pageInputIconSelectFromYourCurrentEmailMasks string ID
+          // label.textContent = browser.i18n.getMessage("pageInputIconSelectFromYourCurrentEmailMasks");
+          label.textContent = "Select from your current email masks";
+        }
 
         if (masks.length > 0) {
           // Populate mask lists, but filter by current website

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -1,4 +1,4 @@
-// Let usage. We need a global object of massk to between all inpage_menu functions 
+// Let usage. We need a global object of massk to between all inpage_menu functions
 let masks = {};
 
 async function iframeCloseRelayInPageMenu() {
@@ -11,7 +11,7 @@ function getRelayMenuEl() {
 }
 
 let activeElemIndex = 0;
-async function handleKeydownEvents (e) {
+async function handleKeydownEvents(e) {
   const relayInPageMenu = getRelayMenuEl();
   const clickableElsInMenu =
     relayInPageMenu.querySelectorAll("button, a, input");
@@ -55,15 +55,17 @@ async function isUserSignedIn() {
 
 async function getCachedServerStoragePref() {
   const serverStoragePref = await browser.storage.local.get("server_storage");
-  const serverStoragePrefInStorage =
-    Object.prototype.hasOwnProperty.call(serverStoragePref, "server_storage");
+  const serverStoragePrefInStorage = Object.prototype.hasOwnProperty.call(
+    serverStoragePref,
+    "server_storage"
+  );
 
   if (!serverStoragePrefInStorage) {
     return await browser.runtime.sendMessage({
       method: "getServerStoragePref",
     });
   } else {
-    // The user has this pref set. Return the value
+    // If the stored pref exists, return value
     return serverStoragePref.server_storage;
   }
 }
@@ -77,7 +79,6 @@ async function getMasks(options = { fetchCustomMasks: false }) {
         method: "getAliasesFromServer",
         options,
       });
-
     } catch (error) {
       console.warn(`getAliasesFromServer Error: ${error}`);
 
@@ -102,20 +103,18 @@ async function fillTargetWithRelayAddress(generateClickEvt) {
   const maskAddress = generateClickEvt.target.dataset.mask;
   const maskAddressId = generateClickEvt.target.dataset.maskId;
 
-  console.log("toBeFiltered", masks);
-  
-
-  const maskObject = masks.find(mask => mask.id === parseInt(maskAddressId, 10));
+  const maskObject = masks.find(
+    (mask) => mask.id === parseInt(maskAddressId, 10)
+  );
 
   const currentUsedOnValue = maskObject.used_on;
 
-  const used_on = {};
+  // TODO: used_on
+  // const used_on = {};
 
   const currentPageHostName = await browser.runtime.sendMessage({
     method: "getCurrentPageHostname",
   });
-
-  console.log("currentUsedOnValue", currentUsedOnValue);
 
   if (currentUsedOnValue === null) {
     // This site has not been used on any site before
@@ -123,18 +122,16 @@ async function fillTargetWithRelayAddress(generateClickEvt) {
       method: "patchMaskInfo",
       id: parseInt(maskAddressId, 10),
       data: {
-        used_on: "example.com"
+        used_on: "example.com",
       },
       options: {
         auth: true,
-      }
+      },
     });
   }
 
-  // TODO: Parse currentUsedOnValue object to check if current domain is listed, and if not, add it. 
-  // If you add it, patch it! 
-
-
+  // TODO: Parse currentUsedOnValue object to check if current domain is listed, and if not, add it.
+  // If you add it, patch it!
 
   await browser.runtime.sendMessage({
     method: "fillInputWithAlias",
@@ -148,11 +145,7 @@ async function fillTargetWithRelayAddress(generateClickEvt) {
   });
 }
 
-async function populateMaskList(
-  maskList,
-  masks,
-  options = { replaceMaskAddressWithLabel: false }
-) {
+async function populateFreeMaskList(maskList, masks) {
   const list = maskList.querySelector("ul");
 
   if (masks.length === 0) {
@@ -165,29 +158,13 @@ async function populateMaskList(
 
     listButton.tabIndex = 0;
 
-    console.log("mask object", mask);
-    
     listButton.dataset.domain = mask.domain;
     listButton.dataset.maskId = mask.id;
     listButton.dataset.mask = mask.full_address;
     listButton.dataset.label = mask.description;
 
-    if (options.replaceMaskAddressWithLabel) {
-      // The button text for a mask will show both the description label (if set) and the full address.
-      const listButtonLabel = document.createElement("span");
-      listButtonLabel.classList.add("fx-relay-menu-masks-search-result-label");
-      const listButtonAddress = document.createElement("span");
-      listButtonAddress.classList.add(
-        "fx-relay-menu-masks-search-result-address"
-      );
-      listButtonLabel.textContent = mask.description;
-      listButtonAddress.textContent = mask.full_address;
-      listButton.appendChild(listButtonLabel);
-      listButton.appendChild(listButtonAddress);
-    } else {
-      // The button text for a mask will be either the description label or the full address.
-      listButton.textContent = mask.description || mask.full_address;
-    }
+    // The button text for a mask will be either the description label or the full address.
+    listButton.textContent = mask.description || mask.full_address;
 
     listButton.addEventListener("click", fillTargetWithRelayAddress, false);
 
@@ -203,8 +180,57 @@ async function populateMaskList(
   list.classList.remove("is-loading");
 
   maskList.classList.add("is-visible");
-  
-  // The free UI has both lists wrapped up in a hidden-by-default element, so this makes it visible too. 
+
+  // The free UI has both lists wrapped up in a hidden-by-default element, so this makes it visible too.
+  document.querySelector(".fx-relay-menu-masks-lists")?.classList.add("is-visible");
+
+  await browser.runtime.sendMessage({
+    method: "updateIframeHeight",
+    height: document.getElementById("fxRelayMenuBody").scrollHeight,
+  });
+}
+
+async function populatePremiumMaskList(maskList, masks) {
+  const list = maskList.querySelector("ul");
+
+  if (masks.length === 0) {
+    return;
+  }
+
+  masks.forEach((mask) => {
+    const listItem = document.createElement("li");
+    const listButton = document.createElement("button");
+
+    listButton.tabIndex = 0;
+    listButton.dataset.domain = mask.domain;
+    listButton.dataset.maskId = mask.id;
+    listButton.dataset.mask = mask.full_address;
+    listButton.dataset.label = mask.description;
+
+    // The button text for a mask will show both the description label (if set) and the full address.
+    const listButtonLabel = document.createElement("span");
+    listButtonLabel.classList.add("fx-relay-menu-masks-search-result-label");
+    const listButtonAddress = document.createElement("span");
+    listButtonAddress.classList.add("fx-relay-menu-masks-search-result-address");
+    listButtonLabel.textContent = mask.description;
+    listButtonAddress.textContent = mask.full_address;
+    listButton.appendChild(listButtonLabel);
+    listButton.appendChild(listButtonAddress);
+
+    listButton.addEventListener("click", fillTargetWithRelayAddress, false);
+
+    listItem.appendChild(listButton);
+    list.appendChild(listItem);
+  });
+
+  // Remove loading state
+  const loadingItem = maskList.querySelector(
+    ".fx-relay-menu-masks-list-loading"
+  );
+  loadingItem.remove();
+  list.classList.remove("is-loading");
+
+  // The free UI has both lists wrapped up in a hidden-by-default element, so this makes it visible too.
   document.querySelector(".fx-relay-menu-masks-lists")?.classList.add("is-visible");
 
   await browser.runtime.sendMessage({
@@ -218,11 +244,12 @@ const sendInPageEvent = (evtAction, evtLabel) => {
 };
 
 function applySearchFilter(query) {
-  const maskResults = Array.from(
-    document.querySelectorAll(".fx-relay-menu-masks-search-results ul li")
+  // The search results will only count/return from whichever list is active/visible.
+  const maskSearchResults = Array.from(
+    document.querySelectorAll(".fx-relay-menu-masks-list.is-visible ul li")
   );
 
-  maskResults.forEach((maskResult) => {
+  maskSearchResults.forEach((maskResult) => {
     const button = maskResult.querySelector("button");
     const emailAddress = button.dataset.mask;
     const label = button.dataset.label;
@@ -237,22 +264,18 @@ function applySearchFilter(query) {
     }
   });
 
-  // Add #/# labels to search filter
+  // Set #/# labels inside search bar to show results count
   const searchFilterTotal = document.querySelector(".js-filter-masks-total");
   const searchFilterVisible = document.querySelector(
     ".js-filter-masks-visible"
   );
 
-  searchFilterVisible.textContent = maskResults.length;
-
-  searchFilterVisible.textContent = maskResults.filter(
-    (maskResult) => !maskResult.classList.contains("is-hidden")
-  ).length;
-  searchFilterTotal.textContent = maskResults.length;
+  searchFilterVisible.textContent = maskSearchResults.filter((maskResult) => !maskResult.classList.contains("is-hidden")).length;
+  searchFilterTotal.textContent = maskSearchResults.length;
 }
 
 function checkIfAnyMasksAreUsedOnCurrentWebsite(masks, domain) {
-  return masks.some( mask => {
+  return masks.some((mask) => {
     return domain === mask.generated_for;
   });
 }
@@ -261,7 +284,6 @@ const buildContent = {
   loggedIn: {
     free: async (relaySiteOrigin) => {
       const fxRelayMenuBody = document.getElementById("fxRelayMenuBody");
-
 
       const signedInContentFree = document.querySelector(
         ".fx-content-signed-in-free"
@@ -284,21 +306,24 @@ const buildContent = {
 
       const maskLists = document.querySelectorAll(".fx-relay-menu-masks-list");
       masks = await getMasks();
-      
+
       const currentPageHostName = await browser.runtime.sendMessage({
         method: "getCurrentPageHostname",
       });
 
       maskLists?.forEach(async (maskList) => {
         // Set Mask List label names
-        const label = maskList.querySelector(".fx-relay-menu-masks-list-label");        
+        const label = maskList.querySelector(".fx-relay-menu-masks-list-label");
         const stringId = label.dataset.stringId;
-        
+
         label.textContent = browser.i18n.getMessage(stringId);
 
         // If there are no masks used on the current site, we need to change the label for the other masks:
-        if (!checkIfAnyMasksAreUsedOnCurrentWebsite(masks, currentPageHostName) && maskList.classList.contains("fx-relay-menu-masks-free-other")) {
-          // TODO / BLOCKED: https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n/pull/31 
+        if (
+          !checkIfAnyMasksAreUsedOnCurrentWebsite(masks, currentPageHostName) &&
+          maskList.classList.contains("fx-relay-menu-masks-free-other")
+        ) {
+          // TODO: (BLOCKED) https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n/pull/31
           // needs to merge for pageInputIconSelectFromYourCurrentEmailMasks string ID
           // label.textContent = browser.i18n.getMessage("pageInputIconSelectFromYourCurrentEmailMasks");
           label.textContent = "Select from your current email masks";
@@ -306,14 +331,18 @@ const buildContent = {
 
         if (masks.length > 0) {
           // Populate mask lists, but filter by current website
-          const buildFilteredMaskList = maskList.classList.contains("fx-relay-menu-masks-free-this-website");
+          const buildFilteredMaskList = maskList.classList.contains(
+            "fx-relay-menu-masks-free-this-website"
+          );
 
           // TODO: Check additional field(s) besides "generated_for"
-          const filteredMasks = buildFilteredMaskList ? 
-            masks.filter(mask => mask.generated_for === currentPageHostName)
-            : masks.filter(mask => mask.generated_for !== currentPageHostName);
-          
-          await populateMaskList(maskList, filteredMasks);
+          const filteredMasks = buildFilteredMaskList
+            ? masks.filter((mask) => mask.generated_for === currentPageHostName)
+            : masks.filter(
+                (mask) => mask.generated_for !== currentPageHostName
+              );
+
+          await populateFreeMaskList(maskList, filteredMasks);
         }
       });
 
@@ -359,7 +388,7 @@ const buildContent = {
         generateAliasBtn.focus();
       }
 
-      // TODO: Add premiumCountryAvailability Check 
+      // TODO: Add premiumCountryAvailability Check
       // Check if premium features are available
       // const premiumCountryAvailability = (
       //   await browser.storage.local.get("premiumCountries")
@@ -383,7 +412,6 @@ const buildContent = {
       });
     },
     premium: async () => {
-      
       const fxRelayMenuBody = document.getElementById("fxRelayMenuBody");
 
       const signedInContentFree = document.querySelector(
@@ -398,22 +426,11 @@ const buildContent = {
       signedInContentPremium?.classList.remove("is-hidden");
       signedInContentFree?.remove();
 
-      const searchInput = document.querySelector(
-        ".fx-relay-menu-masks-search-input"
-      );
-
-      searchInput.placeholder = browser.i18n.getMessage("labelSearch");
-
       // Resize iframe
       await browser.runtime.sendMessage({
         method: "updateIframeHeight",
         height: fxRelayMenuBody.scrollHeight,
       });
-
-      const searchResults = document.querySelector(
-        ".fx-relay-menu-masks-search-results"
-      );
-      const searchResultsList = searchResults.querySelector("ul");
 
       // Check if user may have custom domain masks
       const { premiumSubdomainSet } = await browser.storage.local.get(
@@ -423,6 +440,7 @@ const buildContent = {
       // API Note: If a user has not registered a subdomain yet, its default stored/queried value is "None";
       const isPremiumSubdomainSet = premiumSubdomainSet !== "None";
 
+      // Get masks, including subdomain/custom masks if available
       masks = await getMasks({
         fetchCustomMasks: isPremiumSubdomainSet,
       });
@@ -431,119 +449,106 @@ const buildContent = {
       const currentPageHostName = await browser.runtime.sendMessage({
         method: "getCurrentPageHostname",
       });
-      
-      if ( checkIfAnyMasksAreUsedOnCurrentWebsite(masks, currentPageHostName) ) {
 
-        const filterMenu = document.querySelector(".fx-relay-menu-filter-active-site");
+      // See if any masks are assosiated with the current site. 
+      // If so, we'll end up building two discret mask lists:  
+      // 1. Just masks for that specific website
+      // 2. All masks (including ones from the previous list)
+      const userHasMasksForCurrentWebsite =
+        checkIfAnyMasksAreUsedOnCurrentWebsite(masks, currentPageHostName);
+
+      // If there are no masks assosiated with the current site, remove that list entirely.
+      if (!userHasMasksForCurrentWebsite) {
+        document.querySelector(".fx-relay-menu-masks-list-this-website").remove();
+      }
+
+      const maskLists = document.querySelectorAll(".fx-relay-menu-masks-list");
+
+      // Now we can set the toggle buttons between the two lists.
+      if (userHasMasksForCurrentWebsite) {
+        fxRelayMenuBody.classList.add(".fx-relay-mask-list-toggle-height");
+
+        const filterMenu = document.querySelector(
+          ".fx-relay-menu-filter-active-site"
+        );
         filterMenu.classList.add("is-visible");
 
         const filterMenuButtons = filterMenu.querySelectorAll("button");
-        filterMenuButtons.forEach(button => {
+
+        filterMenuButtons.forEach((button) => {
           const stringId = button.dataset.stringId;
-          button.textContent = browser.i18n.getMessage(stringId);          
+          button.textContent = browser.i18n.getMessage(stringId);
+
+          // TODO: Move this function elsewhere
+
+          button.addEventListener("click", async (event) => {
+            await buildContent.components.setMaskListButton(event.target, maskLists, filterMenuButtons);
+          });
         });
-        
       }
 
-      /*
-      TODO
-      1. Check if SOME masks exist on site. 
-      If so, build that list first 
-      Q: Buil both or only build one and rebuild when click
-      Add listners funcs to buttons to show each list
-      CSS: Styls buttons
-      Note: You'll need to filter each search array by active mask list
-      */
+      maskLists?.forEach(async (maskList) => {
 
-      // Process the masks list:
-      if (masks.length === 0) {
-        fxRelayMenuBody.classList.remove("is-loading");
-
-        const search = document.querySelector(".fx-relay-menu-masks-search");
-        search.classList.add("is-hidden");
-
-      } else if (masks.length > 5) {
-
-        // If there's at least 6 masks, show the search bar
-        await populateMaskList(searchResults, masks, {
-          replaceMaskAddressWithLabel: true,
-        });
-
-        searchResultsList.style.height = `${searchResultsList.offsetHeight}px`;
-
-        const filterSearchForm = document.querySelector(
-          ".fx-relay-menu-masks-search-form"
+        // Check if the list we're currently building is "From this website". This logic will be used throughout the function
+        const buildFilteredMaskList = maskList.classList.contains(
+          "fx-relay-menu-masks-list-this-website"
         );
 
-        const filterSearchInput = filterSearchForm.querySelector(
-          ".fx-relay-menu-masks-search-input"
-        );
+        // TODO: Check additional field(s) besides "generated_for"
+        const filteredMasks = buildFilteredMaskList
+          ? masks.filter((mask) => mask.generated_for === currentPageHostName)
+          : masks;
 
-        filterSearchForm.addEventListener("submit", (event) => {
-          event.preventDefault();
-          filterSearchInput.blur();
-        });
+        // Process the masks list based on how many masks there are: 
+        // If there is none, we'll only show the "Generate new mask" button
+        // If there's less than five, we'll show all of them
+        // If there's MORE than five, we'll show all of them and show the search/filter bar
+        if (filteredMasks.length === 0) {
+          if (buildFilteredMaskList) {
+            // We only want to remove the the search field if there's NO masks.
+            return;
+          }
 
-        filterSearchInput.addEventListener("input", (event) => {
-          applySearchFilter(event.target.value);
-        });
+          buildContent.components.search.remove();
+        } else {
+          // Built out each list
+          await populatePremiumMaskList(maskList, filteredMasks);
+        }
+      });
 
-      } else {
-        // User has between 1-5 masks. Display all of them, but
-        // do not show the search input/filter.
-
-        await populateMaskList(searchResults, masks, {
-          replaceMaskAddressWithLabel: true,
-        });
-
-        const filterSearchForm = document.querySelector(
-          ".fx-relay-menu-masks-search-form"
-        );
-
-        const filterSearchResults = document.querySelector(
-          ".fx-relay-menu-masks-search-results"
-        );
-
-        filterSearchForm.remove();
-        filterSearchResults.classList.add("t-no-search-bar");
-      }
-
-    
-      const generateAliasBtn = document.querySelector(
-        ".fx-relay-menu-generate-alias-btn"
-      );
+      // Set the first available list to visible.
+      // If there's "From this website" masks, it will show that list first. 
+      document.querySelector(".fx-relay-menu-masks-list").classList.add("is-visible");
 
       // Set Generate Mask button
       await buildContent.components.generateMaskButton();
 
       fxRelayMenuBody.classList.remove("is-loading");
 
-      // Resize iframe
+      // Check if search has been removed. If not, init it!  
+      const search = document.querySelector(".fx-relay-menu-masks-search");
+      if (search) {
+        await buildContent.components.search.init();
+        const filterSearchForm = document.querySelector(
+          ".fx-relay-menu-masks-search-form"
+        );
+
+        // If the visible list has enough masks to show the search bar, focus on it
+        // Note that the buildContent.components.search function also runs the updateIframeHeight event.
+        if (filterSearchForm.classList.contains("is-visible")) {
+          await buildContent.components.search.inputFocus();
+          return;
+        }
+      }
+
+      const generateAliasBtn = document.querySelector(
+        ".fx-relay-menu-generate-alias-btn"
+      );
+
       await browser.runtime.sendMessage({
         method: "updateIframeHeight",
         height: fxRelayMenuBody.scrollHeight,
       });
-
-      const filterSearchInput = document.querySelector(
-        ".fx-relay-menu-masks-search-input"
-      );
-
-      if (filterSearchInput) {
-        // If there's a search bar visible, focus on that instead of the generate
-
-        const searchFilterTotal = document.querySelector(
-          ".js-filter-masks-total"
-        );
-        const searchFilterVisible = document.querySelector(
-          ".js-filter-masks-visible"
-        );
-
-        searchFilterTotal.textContent = masks.length;
-        searchFilterVisible.textContent = masks.length;
-
-        filterSearchInput.focus();
-        return;
-      }
 
       // Focus on "Generate New Alias" button
       generateAliasBtn.focus();
@@ -606,6 +611,43 @@ const buildContent = {
     }, 10);
   },
   components: {
+    setMaskListButton: async (button, maskLists, filterMenuButtons) => {
+        // Hide all lists, show selected list
+        maskLists.forEach((maskList) => {
+          maskList.classList.remove("is-visible");
+        });
+
+        const maskListSelector = button.dataset.maskList;
+        const activeMaskList = document.querySelector(maskListSelector);
+        const activeMaskListCount = activeMaskList.querySelectorAll("li");
+
+        activeMaskList.classList.add("is-visible");
+
+        const filterSearchForm = document.querySelector(
+          ".fx-relay-menu-masks-search-form"
+        );
+        
+        // If there's enough masks in this list, we need to show search.
+        if (activeMaskListCount.length > 5) {
+          filterSearchForm.classList.add("is-visible");
+          await buildContent.components.search.inputFocus();
+        } else {
+          filterSearchForm.classList.remove("is-visible");
+        }
+
+        // Make all buttons inactive, make selected button active
+        filterMenuButtons.forEach((maskList) => {
+          maskList.classList.remove("is-active");
+        });
+
+        button.classList.add("is-active");
+
+        // Resize iframe
+        await browser.runtime.sendMessage({
+          method: "updateIframeHeight",
+          height: document.getElementById("fxRelayMenuBody").scrollHeight,
+        });      
+    },
     generateMaskButton: async () => {
       // Create "Generate Relay Address" button
       const generateAliasBtn = document.querySelector(
@@ -635,10 +677,12 @@ const buildContent = {
         });
 
         // Catch edge cases where the "Generate New Alias" button is still enabled,
-        // but the user has already reached the max number of aliases. 
+        // but the user has already reached the max number of aliases.
         if (newRelayAddressResponse.status === 402) {
           generateClickEvt.target.classList.remove("is-loading");
-          throw new Error(browser.i18n.getMessage("pageInputIconMaxAliasesError_mask"));
+          throw new Error(
+            browser.i18n.getMessage("pageInputIconMaxAliasesError_mask")
+          );
         }
 
         await browser.runtime.sendMessage({
@@ -673,21 +717,113 @@ const buildContent = {
       const relayMenuDashboardLink = document.querySelector(
         ".fx-relay-menu-dashboard-link"
       );
-    
+
       const relayMenuDashboardLinkTooltip =
-        relayMenuDashboardLink.querySelector(".fx-relay-menu-dashboard-link-tooltip");
-    
-        relayMenuDashboardLinkTooltip.textContent =
+        relayMenuDashboardLink.querySelector(
+          ".fx-relay-menu-dashboard-link-tooltip"
+        );
+
+      relayMenuDashboardLinkTooltip.textContent =
         browser.i18n.getMessage("labelManage");
-    
+
       relayMenuDashboardLink.href = `${relaySiteOrigin}?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=manage-all-addresses`;
       relayMenuDashboardLink.target = "_blank";
-    
+
       relayMenuDashboardLink.addEventListener("click", async () => {
         sendInPageEvent("click", "input-menu-manage-all-aliases-btn");
         await iframeCloseRelayInPageMenu();
       });
-    }
+    },
+    search: {
+      inputFocus: async () => {
+        // If there's a search bar visible, focus on that instead of the generate
+        const filterSearchInput = document.querySelector(
+          ".fx-relay-menu-masks-search-input"
+        );
+
+        const searchFilterTotal = document.querySelector(
+          ".js-filter-masks-total"
+        );
+
+        const searchFilterVisible = document.querySelector(
+          ".js-filter-masks-visible"
+        );
+
+        const maskSearchResults = document.querySelectorAll(
+          ".fx-relay-menu-masks-list.is-visible ul li"
+        );
+
+        searchFilterTotal.textContent = maskSearchResults.length;
+        searchFilterVisible.textContent = maskSearchResults.length;
+
+        // Resize iframe
+        await browser.runtime.sendMessage({
+          method: "updateIframeHeight",
+          height: document.getElementById("fxRelayMenuBody").scrollHeight,
+        });
+
+        filterSearchInput.focus();
+      },
+      init: async () => {
+        const filterSearchForm = document.querySelector(
+          ".fx-relay-menu-masks-search-form"
+        );
+
+        const filterSearchInput = filterSearchForm.querySelector(
+          ".fx-relay-menu-masks-search-input"
+        );
+
+        filterSearchInput.placeholder = browser.i18n.getMessage("labelSearch");
+
+        filterSearchForm.addEventListener("submit", (event) => {
+          event.preventDefault();
+          filterSearchInput.blur();
+        });
+
+        filterSearchInput.addEventListener("input", (event) => {
+          applySearchFilter(event.target.value);
+        });
+
+        const maskLists = document.querySelectorAll(
+          ".fx-relay-menu-masks-list"
+        );
+
+        maskLists.forEach((maskList) => {
+          const maskNumber = maskList.querySelectorAll("li").length;
+          if (maskNumber > 5) {
+            if (maskList.classList.contains("is-visible")) {
+              buildContent.components.search.show();
+              return;
+            }
+
+            return;
+          }
+
+          maskList.classList.add("t-no-search-bar");
+        });
+
+        // Resize iframe
+        await browser.runtime.sendMessage({
+          method: "updateIframeHeight",
+          height: document.getElementById("fxRelayMenuBody").scrollHeight,
+        });
+      },
+      remove: () => {
+        const search = document.querySelector(".fx-relay-menu-masks-search");
+        search.remove();
+      },
+      show: () => {
+        const filterSearchForm = document.querySelector(
+          ".fx-relay-menu-masks-search-form"
+        );
+        filterSearchForm.classList.add("is-visible");
+
+        const maskListUl = document.querySelector(
+          ".fx-relay-menu-masks-list.is-visible ul"
+        );
+        maskListUl.style.height = `${maskListUl.offsetHeight}px`;
+      },
+    },
   },
 };
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Firefox Relay",
-  "version": "2.3.4",
+  "version": "2.3.5",
 
   "description": "__MSG_extensionDescription_mask__",
 


### PR DESCRIPTION
## Summary

[MPP-1638](https://mozilla-hub.atlassian.net/browse/MPP-1638) 

Blocked (Cannot submit to AMO until) by: 
- https://github.com/mozilla/fx-private-relay/pull/1968
- https://github.com/mozilla/fx-private-relay/pull/1969

This PR adds additional functionality to the in-page menu. Now, when users fill in email inputs using the add-on, we will remember that and service it the next time they're on the site. 

## Caveats

- ~Local storage only (not syncing with the server) has not been tested/is not currently supported~
- ~Website limitation:  `domainaddresses` does not yet support the `used_on` field~
- This functionality does not apply to context-menu/alt-clicking
  - Draft started https://github.com/mozilla/fx-private-relay-add-on/pull/342

## Testing

### Free account: 

- Start with an empty account (with sync enabled)
- Create a few masks from the dashboard page
  - _Optional: Set a label_
- Go to a website with an email input form
- Click on the Relay icon
- **Expected:** The in-page menu should open up with the masks in the "Select from your current email masks" list
  - _Note: If you set a label, it should show the label in this list, rather than the mask address._
- Click on a mask
- **Expected:** The mask address should be auto-filled into the email input
- Click on the Relay icon again
- **Expected:** The in-page menu should open up with that selected mask now in the "Previously used on this website" list 
  - _Note: If you created multiple masks, there will now be two lists: "Select from your current email masks" and "Previously used on this website"_
- Click on "Generate new mask" button
- **Expected:** A mask address should be created and then auto-filled into the email input
- Click on the Relay icon again
- **Expected:** There should be two items in the "Previously used on this website" list 
  - _Note: The newest mask address should have a label of the current website you're on._

### Premium Account

- Start with a premium, empty account (with sync enabled)
- Create a few masks from the dashboard page
  - _Note: If you create a custom mask (with a registered subdomain), this will NOT work until https://github.com/mozilla/fx-private-relay/pull/1968 is merged. You can still re-use these with the add-on, but it will not save/store site usage._
- Go to a website with an email input form
- **Expected:** The in-page menu should open up with the masks from a single (unlabeled) list. 
  - _Optional: If you created over five masks, you should have a search field to search that visible list of masks._
- Click on a mask
- **Expected:** The mask address should be auto-filled into the email input
- Click on the Relay icon again
- **Expected:** There are now TWO lists (with navigation buttons at the top of the menu): From this website / All email masks. The email mask you selected previously is in "From this website" list.
  - _Note: The "All email masks" will list every mask created for the user, including ones from on the "From this website" list_
- Click on "Generate new mask" button
- **Expected:** A mask address should be created and then auto-filled into the email input
- Click on the Relay icon again
- **Expected:** There should be two items in the "From this website" list 
  - _Note: The newest mask address should have a label of the current website you're on._
- Go back to the dashboard and create enough masks to have at least six.
- Go back to the same previous website
- Click on the Relay icon
- **Expected:** There should still be two lists: From this website / All email masks 
- Click on "All email masks" label to switch lists
- **Expected:** There should a search bar that appears (and it should filter as expected too!) 

## Screenshots

Free account with know mask association with current site: 

<img width="444" alt="image" src="https://user-images.githubusercontent.com/2692333/168107625-77af35c2-c615-4a9b-a4e6-dc27e7217c5c.png">

Premium account with know mask association with current site: 
<img width="416" alt="image" src="https://user-images.githubusercontent.com/2692333/168945741-90ac065d-b837-4ae4-92bf-5c5e6ca64df5.png">

<img width="417" alt="image" src="https://user-images.githubusercontent.com/2692333/168945747-c14bbf70-9061-4ea3-8fc6-8d59522c8051.png">

