### PR TITLE
Add local-storage (no server) sync support for new in-page menu

### DIFF
--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -60,13 +60,13 @@ async function getCachedServerStoragePref() {
       method: "getServerStoragePref",
     });
   } else {
-    return serverStoragePrefInStorage;
+    return serverStoragePref.server_storage;
   }
 }
 
 async function getMasks(options = { fetchCustomMasks: false }) {
   const serverStoragePref = await getCachedServerStoragePref();
-
+  
   if (serverStoragePref) {
     try {
       const masks = await browser.runtime.sendMessage({
@@ -89,6 +89,9 @@ async function getMasks(options = { fetchCustomMasks: false }) {
 
   // User is not syncing with the server. Use local storage.
   const { relayAddresses } = await browser.storage.local.get("relayAddresses");
+
+  relayAddresses.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+  
   return relayAddresses;
 }
 


### PR DESCRIPTION
## Summary 

Fixes #331 

Note - There's a lot in common with https://github.com/mozilla/fx-private-relay-add-on/pull/320, except this adds some additional helper functions to store label data in the add-on local data (necessary for building the mask list on in-page content) 

### TODO: 

- [ ] Update local data when an alias is deleted 

## Testing Steps

### Free 
- Create new account
- Before adding/creating masks: Go to Profile > Settings
- Uncheck "Privacy" checkbox 
- Create label 
- Go to website
- **Expected:** List includes label name, rather than mask name
- Generate mask on website, using the in-page content menu
- Go to dashboard
- **Expected:** New mask should have label set to name of website where generated 
- Go back to another test page, click Relay Icon to open in-page menu:
- **Expected:** The list should match the same mask order as the desktop AND if any masks have labels set, it should work. 

### Premium
- Create new account
-  Before adding/creating masks: Go to Profile > Settings
- Uncheck "Privacy" checkbox 
- Upgrade account to premium
- Register subdomain name 
- Follow steps from above