### PR TITLE
Align get_profile_data with recent changes

### DIFF
--- a/src/js/relay.firefox.com/installation_indicator.js
+++ b/src/js/relay.firefox.com/installation_indicator.js
@@ -15,7 +15,10 @@
       const localLabels = localRandomAliasCache
         .filter(address => address.description.length > 0)
         .map(address => ({
-          type: "random",
+          // `type` can be removed as soon as the website is updated to watch
+          // for mask_type
+          type: address.mask_type ?? "random",
+          mask_type: address.mask_type,
           id: Number.parseInt(address.id, 10),
           description: address.description,
           generated_for: address.generated_for,


### PR DESCRIPTION
This updates it to:
- store custom masks in the (confusingly-named) `relayAddresses`
  local storage key as well
- preserve the new used_on property when uploading local data to
  the API
- make use of the `mask_type` property on masks to distinguish
  between local and random masks

With that, I think it should fix the issues called out by @maxxcrawford in https://github.com/mozilla/fx-private-relay/pull/1969#pullrequestreview-982253905.

Note that this change should not be dependent on any website changes that aren't already in `main`.