### PR TITLE
Fix continuous prerelease to GitHub

### DIFF
--- a/.github/workflows/sign-and-release-to-github.yml
+++ b/.github/workflows/sign-and-release-to-github.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: fx-private-relay-stage.xpi
-          path: web-ext-artifacts/firefox_relay-${{ steps.version.outputs.version }}-an+fx.xpi
+          path: web-ext-artifacts/firefox_relay-${{ steps.version.outputs.version }}.xpi
 
       - uses: actions/upload-artifact@v2
         with:
@@ -156,7 +156,7 @@ jobs:
       #     repo: fx-private-relay-add-on
       #     release_id: ${{ fromJson(steps.create_release.outputs.data).id }}
       #     body: # TODO: Figure out how to pass the binary data of
-      #           #       ./web-ext-artifacts/firefox_relay-${{ steps.version.outputs.version }}-an+fx.xpi
+      #           #       ./web-ext-artifacts/firefox_relay-${{ steps.version.outputs.version }}.xpi
       #           #       here.
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ requirements for AMO signing, the pre-release versions are [Calendar
 Versioned](https://calver.org/) as `YYYY.MM.DD.minutes-since-midnight`
 
 The signed `.xpi` file is named
-`firefox_relay-${{ YYYY.MM.DD.minutes }}-an+fx.xpi` and automatically attached
+`firefox_relay-${{ YYYY.MM.DD.minutes }}.xpi` and automatically attached
 to each release, under the release "Assets" section.
 
 #### Make the new version


### PR DESCRIPTION
Somewhere between 2022-05-12 [1] and 2022-05-16 [2], `web-ext sign`
(or the API behind it) started producing different filenames, which
meant that the artefact uploader could no longer find the output.

See the output of the sign jobs:

![image](https://user-images.githubusercontent.com/4251/170023667-311b3d7c-9ca6-4773-bd24-941292395fd1.png)

vs.

![image](https://user-images.githubusercontent.com/4251/170023785-45d8db10-7393-4c61-9fa0-c0b3815db75e.png)

[1] https://github.com/mozilla/fx-private-relay-add-on/actions/runs/2310548121
[2] https://github.com/mozilla/fx-private-relay-add-on/actions/runs/2329060749