### PR TITLE
Also deal with renamed artefacts

### DIFF
--- a/.github/workflows/sign-and-release-to-github.yml
+++ b/.github/workflows/sign-and-release-to-github.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: fx-private-relay-stage.xpi
-          path: web-ext-artifacts/firefox_relay-${{ steps.version.outputs.version }}.xpi
+          path: web-ext-artifacts/private_relay-${{ steps.version.outputs.version }}.xpi
 
       - uses: actions/upload-artifact@v2
         with:
@@ -156,7 +156,7 @@ jobs:
       #     repo: fx-private-relay-add-on
       #     release_id: ${{ fromJson(steps.create_release.outputs.data).id }}
       #     body: # TODO: Figure out how to pass the binary data of
-      #           #       ./web-ext-artifacts/firefox_relay-${{ steps.version.outputs.version }}.xpi
+      #           #       ./web-ext-artifacts/private_relay-${{ steps.version.outputs.version }}.xpi
       #           #       here.
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ requirements for AMO signing, the pre-release versions are [Calendar
 Versioned](https://calver.org/) as `YYYY.MM.DD.minutes-since-midnight`
 
 The signed `.xpi` file is named
-`firefox_relay-${{ YYYY.MM.DD.minutes }}.xpi` and automatically attached
+`private_relay-${{ YYYY.MM.DD.minutes }}.xpi` and automatically attached
 to each release, under the release "Assets" section.
 
 #### Make the new version


### PR DESCRIPTION
Followup of https://github.com/mozilla/fx-private-relay-add-on/pull/345 - apparently the `.xpi` name is also different. @maxxcrawford any idea what could have caused this? Any risk of this reverting back to the old name later?