### PR TITLE
Bug Fix: Store used_on data locally for non-sync users

### DIFF
--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -284,6 +284,8 @@ async function makeRelayAddress(description = null) {
   const updatedLocalRelayAddresses = localRelayAddresses.relayAddresses.concat([
     newRelayAddressJson,
   ]);
+
+  updatedLocalRelayAddresses.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
   
   browser.storage.local.set({ relayAddresses: updatedLocalRelayAddresses });
   return newRelayAddressJson;

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -399,6 +399,8 @@ const buildContent = {
               (mask) => mask.generated_for !== currentPageHostName && !hasMaskBeenUsedOnCurrentSite(mask, currentPageHostName)
               );
 
+          filteredMasks.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+
           await populateFreeMaskList(maskList, filteredMasks);
         }
       });

--- a/src/js/relay.firefox.com/get_profile_data.js
+++ b/src/js/relay.firefox.com/get_profile_data.js
@@ -152,6 +152,9 @@
           );
         });
 
+        console.log("localAddressCache/matchingLocalAddress?.used_on", matchingLocalAddress?.used_on);
+        console.log("localAddressCache/address.used_on", address.used_on);
+
         return {
           ...address,
           description: matchingLocalAddress?.description ?? address.description,
@@ -212,6 +215,10 @@
         if (typeof alias.generated_for === "string" && alias.generated_for.length > 0) {
           return true;
         }
+
+        if (typeof alias.used_on === "string" && alias.used_on.length > 0) {
+          return true;
+        }
       }
     }
 
@@ -235,7 +242,7 @@
     // be sure it matches the local storage metadata dataset
     function getAliasesWithUpdatedMetadata(updatedAliases, prevAliases) {
       return prevAliases.map(prevAlias => {
-        const updatedAlias = updatedAliases.find(otherAlias => otherAlias.id === prevAlias.id) ?? { description: "", generated_for: ""};
+        const updatedAlias = updatedAliases.find(otherAlias => otherAlias.id === prevAlias.id) ?? { description: "", generated_for: "", used_on: ""};
         return {
           ...prevAlias,
           description: updatedAlias.description.length > 0 ? updatedAlias.description : prevAlias.description,

--- a/src/js/relay.firefox.com/get_profile_data.js
+++ b/src/js/relay.firefox.com/get_profile_data.js
@@ -152,9 +152,6 @@
           );
         });
 
-        console.log("localAddressCache/matchingLocalAddress?.used_on", matchingLocalAddress?.used_on);
-        console.log("localAddressCache/address.used_on", address.used_on);
-
         return {
           ...address,
           description: matchingLocalAddress?.description ?? address.description,

--- a/src/js/relay.firefox.com/installation_indicator.js
+++ b/src/js/relay.firefox.com/installation_indicator.js
@@ -22,6 +22,7 @@
           id: Number.parseInt(address.id, 10),
           description: address.description,
           generated_for: address.generated_for,
+          used_on: address.used_on,
           address: address.address,
         })
       );


### PR DESCRIPTION
Fixes #347 

## Summary: 

This PR adds logic to store `used_on` data locally for users who do not sync data with our servers. It should the same as users who sync their storage. 

## Test: 

_Note: Run through these steps with both free and premium tier accounts_

### Free Account

- Log into Relay with account that DOES NOT sync labels with server
  - Go to settings page `/accounts/settings/` and uncheck Collect data checkbox
- Create a few masks from the dashboard page and set labels
- Go to a website with an email input form
- Click on the Relay icon
- **Expected:** The in-page menu should open up with the masks in the "Select from your current email masks" list
  - _Note: If you set a label, it should show the label in this list, rather than the mask address._
- Click on a mask
- **Expected:** The mask address should be auto-filled into the email input
- Click on the Relay icon again
- **Expected:** The in-page menu should open up with that selected mask now in the "Previously used on this website" list 
  - _Note: If you created multiple masks, there will now be two lists: "Select from your current email masks" and "Previously used on this website"_
- Click on "Generate new mask" button
- **Expected:** A mask address should be created and then auto-filled into the email input
- Click on the Relay icon again
- **Expected:** There should be two items in the "Previously used on this website" list 
  - _Note: The newest mask address should have a label of the current website you're on._

### Premium Account

- Start with a premium, empty account (with sync disabled)
- Create a few masks from the dashboard page including a custom mask (with a registered subdomain)
- Go to a website with an email input form
- **Expected:** The in-page menu should open up with the masks from a single (unlabeled) list. 
  - _Optional: If you created over five masks, you should have a search field to search that visible list of masks._
- Click on a mask
- **Expected:** The mask address should be auto-filled into the email input
- Click on the Relay icon again
- **Expected:** There are now TWO lists (with navigation buttons at the top of the menu): From this website / All email masks. The email mask you selected previously is in "From this website" list.
  - _Note: The "All email masks" will list every mask created for the user, including ones from on the "From this website" list_
- Click on "Generate new mask" button
- **Expected:** A mask address should be created and then auto-filled into the email input
- Click on the Relay icon again
- **Expected:** There should be two items in the "From this website" list 
  - _Note: The newest mask address should have a label of the current website you're on._
- Go back to the dashboard and create enough masks to have at least six.
- Go back to the same previous website
- Click on the Relay icon
- **Expected:** There should still be two lists: From this website / All email masks 
- Click on "All email masks" label to switch lists
- **Expected:** There should a search bar that appears (and it should filter as expected too!) 



