### PR TITLE
Fixing web combat disappearing input issue

### DIFF
--- a/src/js/other-websites/fill_relay_address.js
+++ b/src/js/other-websites/fill_relay_address.js
@@ -15,6 +15,7 @@ function fillInputWithAlias(emailInput, relayAlias) {
   // Set the value of the target field to the selected/generated mask
   emailInput.value = emailMask;
 
+
   emailInput.dispatchEvent(new Event('input', {bubbles:true}));
 
 }
@@ -37,23 +38,9 @@ browser.runtime.onMessage.addListener((message, _sender, _response) => {
 
     // COMPATIBILITY NOTE: getTargetElement() not available on Chrome contextMenus API
     const emailInput = browser.menus ? browser.menus.getTargetElement(message.targetElementId): clickedEl;
-    // console.log(emailInput.value);
-
-     fillInputWithAlias(emailInput, message.relayAddress);
-    // const relayMasks = message.relayAddress;
-    // const emailMask = (relayMasks.full_address) ? relayMasks.full_address : relayMasks.address;
-
-    // forceSetVal(emailInput, emailMask);
-
+    fillInputWithAlias(emailInput, message.relayAddress);
   }
 });
 
-// function forceSetVal(emailInput, emailMask) {
-//   if (!emailInput || !relayAlias) {
-//     return false;
-//   }
 
-//   emailInput.value = emailMask;
-//   emailInput.dispatchEvent(new Event('input', {bubbles:true}));
 
-// }

--- a/src/js/other-websites/fill_relay_address.js
+++ b/src/js/other-websites/fill_relay_address.js
@@ -14,6 +14,9 @@ function fillInputWithAlias(emailInput, relayAlias) {
 
   // Set the value of the target field to the selected/generated mask
   emailInput.value = emailMask;
+
+  emailInput.dispatchEvent(new Event('input', {bubbles:true}));
+
 }
 
 
@@ -34,24 +37,23 @@ browser.runtime.onMessage.addListener((message, _sender, _response) => {
 
     // COMPATIBILITY NOTE: getTargetElement() not available on Chrome contextMenus API
     const emailInput = browser.menus ? browser.menus.getTargetElement(message.targetElementId): clickedEl;
-    console.log(emailInput.value);
+    // console.log(emailInput.value);
 
-    //  fillInputWithAlias(emailInput, message.relayAddress);
-    const relayMasks = message.relayAddress;
-    const emailMask = (relayMasks.full_address) ? relayMasks.full_address : relayMasks.address;
+     fillInputWithAlias(emailInput, message.relayAddress);
+    // const relayMasks = message.relayAddress;
+    // const emailMask = (relayMasks.full_address) ? relayMasks.full_address : relayMasks.address;
 
-    forceSetVal(emailInput, emailMask);
-
-    console.log(emailInput.value);
-    //  console.log(message.relayAddress);
-    console.log(emailInput);
+    // forceSetVal(emailInput, emailMask);
 
   }
 });
 
+// function forceSetVal(emailInput, emailMask) {
+//   if (!emailInput || !relayAlias) {
+//     return false;
+//   }
 
-function forceSetVal(emailInput, emailMask) {
-  emailInput.value = emailMask;
-  emailInput.dispatchEvent(new Event('input', {bubbles:true}));
+//   emailInput.value = emailMask;
+//   emailInput.dispatchEvent(new Event('input', {bubbles:true}));
 
-}
+// }

--- a/src/js/other-websites/fill_relay_address.js
+++ b/src/js/other-websites/fill_relay_address.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-redeclare
 function fillInputWithAlias(emailInput, relayAlias) {
+
   // BUG: Duplicate fillInputWithAlias calls without proper input content
   // The relayAlias/emailInput arguments check below is a work-around to let the duplicate call(s) fail silently. 
   // To debug, check all instances where fillInputWithAlias() is being called and isolate it. 
@@ -13,13 +14,8 @@ function fillInputWithAlias(emailInput, relayAlias) {
 
   // Set the value of the target field to the selected/generated mask
   emailInput.value = emailMask;
-
-  emailInput.dispatchEvent(
-    new InputEvent("relay-address", {
-      data: emailMask,
-    })
-  );
 }
+
 
 // COMPATIBILITY NOTE: browser.menus.getTargetElement is not available so 
 // we have to listen for any contextmenu click to determe the target element.
@@ -37,9 +33,25 @@ browser.runtime.onMessage.addListener((message, _sender, _response) => {
   if (message.type === "fillTargetWithRelayAddress") {    
 
     // COMPATIBILITY NOTE: getTargetElement() not available on Chrome contextMenus API
-    const emailInput = browser.menus
-          ? browser.menus.getTargetElement(message.targetElementId)
-          : clickedEl
-    return fillInputWithAlias(emailInput, message.relayAddress);
+    const emailInput = browser.menus ? browser.menus.getTargetElement(message.targetElementId): clickedEl;
+    console.log(emailInput.value);
+
+    //  fillInputWithAlias(emailInput, message.relayAddress);
+    const relayMasks = message.relayAddress;
+    const emailMask = (relayMasks.full_address) ? relayMasks.full_address : relayMasks.address;
+
+    forceSetVal(emailInput, emailMask);
+
+    console.log(emailInput.value);
+    //  console.log(message.relayAddress);
+    console.log(emailInput);
+
   }
 });
+
+
+function forceSetVal(emailInput, emailMask) {
+  emailInput.value = emailMask;
+  emailInput.dispatchEvent(new Event('input', {bubbles:true}));
+
+}


### PR DESCRIPTION

When generating an email mask the following websites, the add-on then click away from that field the email mask clears from the text field. This PR should solve that bug by setting the `bubbles` property to true in the `Event` construction.


Preview:

https://user-images.githubusercontent.com/13066134/171930577-27db4354-db3e-45eb-a29e-8effe51a92f4.mov




List of sites the bug occurs on for testing: 
[New York Times](https://www.nytimes.com/)
[Zazzle](http://zazzle.com/) account registration 
[Ebay](https://www.ebay.com/)
[Homedepot](http://homedepot.com/) account registration