### PR TITLE
Remove transitionary "type" property on masks

### DIFF
--- a/src/js/relay.firefox.com/inject_addon_data.js
+++ b/src/js/relay.firefox.com/inject_addon_data.js
@@ -15,9 +15,6 @@
       const localLabels = localRandomAliasCache
         .filter(address => address.description.length > 0)
         .map(address => ({
-          // `type` can be removed as soon as the website is updated to watch
-          // for mask_type
-          type: address.mask_type ?? "random",
           mask_type: address.mask_type,
           id: Number.parseInt(address.id, 10),
           description: address.description,


### PR DESCRIPTION
This property was preserved to ensure that if the add-on update
reached people before the website update, people's experience
wouldn't break. However, now that the website has been updated to
look for the mask_type property, we no longer need to inject the
redundant and deprecated type property.

This is the (independent) sister PR to https://github.com/mozilla/fx-private-relay/pull/2050 and a follow-up to https://github.com/mozilla/fx-private-relay-add-on/pull/344.