### PR TITLE
Reduced `z-index` on email field wrapper 

### DIFF
--- a/src/css/relay.css
+++ b/src/css/relay.css
@@ -41,7 +41,7 @@
   border: 0;
 }
 
-.fx-relay-menu-iframe iframe { 
+.fx-relay-menu-iframe iframe {
   border-radius: 4px;
   background: var(--relayGrey10);
   background-color: var(--relayGrey10);
@@ -50,7 +50,7 @@
   animation: fxRelayFadeIn 0.2s ease forwards;
 }
 
-.fx-relay-menu-iframe { 
+.fx-relay-menu-iframe {
   width: 320px;
   /* The top/right positioning here is necessary to align the box correctly (offset) underneath the "triangle" directly below the in-page Relay logo */
   top: 47px;
@@ -146,7 +146,7 @@ fx-relay-logomark {
   pointer-events: none;
   padding: 0 !important;
   width: 100%;
-  z-index: 99999999999999999;
+  z-index: 10;
 }
 
 .fx-relay-email-input-wrapper > input {


### PR DESCRIPTION
## Problem
Users who had Relay enabled experienced issues of having the email input field stacking on top of almost any other element on the page. Here's an example: 
<img width="724" alt="Screen Shot 2022-06-13 at 3 42 36 PM" src="https://user-images.githubusercontent.com/42309026/173287371-ddadb31e-158a-46bf-aea5-488669dedeee.png">

## Original issue
https://github.com/mozilla/fx-private-relay-add-on/issues/22

## My solution
With this fix, I mainly just reduced the `z-index` from `9999999999999....` to a `10`. I tested this out and this is the result:
<img width="956" alt="Screen Shot 2022-06-23 at 11 54 10 AM" src="https://user-images.githubusercontent.com/42309026/175190533-65082626-3cfc-4c80-85e7-e117f8f9b894.png">

Maybe this needs more testing, but the issue has been up for some years with no action, so thought I'd take a swing at it. I'm sure there was a reason the `z-index` was so high in the first place. 
