### PR TITLE
Only use exact matches when searching used_on

### DIFF
--- a/src/js/background/context-menu.js
+++ b/src/js/background/context-menu.js
@@ -382,13 +382,9 @@ const relayContextMenus = {
         return false;
       }
 
-      // BUG: Using includes without spliting on ",", there can 
-      // be some false positive results for entries that share the same root domain. 
-      // eg: Github mask would show up on example.github.io
-      // See full conversation: https://github.com/mozilla/fx-private-relay-add-on/pull/342#discussion_r897755698
       return relayAddresses.some(
         (alias) =>
-          website === alias.generated_for || alias.used_on?.includes(website)
+          website === alias.generated_for || alias.used_on?.split(",").includes(website)
       );
     },
     getHostnameFromUrlConstructor: (url) => {
@@ -401,7 +397,7 @@ const relayContextMenus = {
       // Remove any sites that match the current site (inverse of getSiteSpecificAliases())
       const filteredAliases = array.filter(
         (alias) =>
-          alias.generated_for !== domain && !alias.used_on?.includes(domain)
+          alias.generated_for !== domain && !alias.used_on?.split(",").includes(domain)
       );
 
       // Limit to 5
@@ -462,7 +458,7 @@ const relayContextMenus = {
       }
 
       // Domain already exists in used_on field. Just return the list!
-      if (domainList.includes(currentDomain)) {
+      if (domainList.split(",").includes(currentDomain)) {
         return domainList;
       }
 
@@ -484,7 +480,7 @@ const relayContextMenus = {
       }
 
       // Domain already exists in used_on field. Just return the list!
-      if (domainList.includes(domain)) {
+      if (domainList.split(",").includes(domain)) {
         return true;
       }
 

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -108,7 +108,7 @@ function checkAndStoreUsedOnDomain(domainList, currentDomain) {
   }
  
   // Domain already exists in used_on field. Just return the list!
-  if (domainList.includes(currentDomain)) {
+  if (domainList.split(",").includes(currentDomain)) {
     return domainList;
   }
 
@@ -320,10 +320,6 @@ function applySearchFilter(query) {
 }
 
 function checkIfAnyMasksWereGeneratedOnCurrentWebsite(masks, domain) {
-  // BUG: Using includes without spliting on ",", there can 
-  // be some false positive results for entries that share the same root domain. 
-  // eg: Github mask would show up on example.github.io
-  // See full conversation: https://github.com/mozilla/fx-private-relay-add-on/pull/342#discussion_r897755698
   return masks.some((mask) => {
     return domain === mask.generated_for;
   });
@@ -338,7 +334,7 @@ function hasMaskBeenUsedOnCurrentSite(mask, domain) {
   }
 
   // Domain already exists in used_on field. Just return the list!
-  if (domainList.includes(domain)) {
+  if (domainList.split(",").includes(domain)) {
     return true;
   }
 
@@ -347,10 +343,6 @@ function hasMaskBeenUsedOnCurrentSite(mask, domain) {
 }
 
 function haveMasksBeenUsedOnCurrentSite(masks, domain) {
-  // BUG: Using includes without spliting on ",", there can 
-  // be some false positive results for entries that share the same root domain. 
-  // eg: Github mask would show up on example.github.io
-  // See full conversation: https://github.com/mozilla/fx-private-relay-add-on/pull/342#discussion_r897755698
   return masks.some((mask) => {
     const domainList = mask.used_on;
 
@@ -360,7 +352,7 @@ function haveMasksBeenUsedOnCurrentSite(masks, domain) {
     }
 
     // Domain already exists in used_on field. Just return the list!
-    if (domainList.includes(domain)) {
+    if (domainList.split(",").includes(domain)) {
       return true;
     }
     // No match found!

--- a/src/js/relay.firefox.com/get_profile_data.js
+++ b/src/js/relay.firefox.com/get_profile_data.js
@@ -199,7 +199,7 @@
       premiumSubdomainSet,
     });
 
-    // Loop through an array of aliases and see if any of them have descriptions or generated_for set.
+    // Loop through an array of aliases and see if any of them have descriptions, generated_for, or used_on set.
     function aliasesHaveStoredMetadata(aliases) {
       for (const alias of aliases) {
         if (


### PR DESCRIPTION
Before, if the string with comma-separated domains in the used_on
field included the current domain, we'd conclude that the
respective mask was used on the current domain — even if there was
just a partial match on the domain. For example, if a mask had
`fox.com` in its used_on field, that mask would then be considered
used on `firefox.com` as well.

With this change, only an exact match on `firefox.com` will count
as being used on that site.

How to test: I didn't find a site to properly test it on (e.g. the hypothetical above doesn't work, both because `firefox.com` immediately redirects to mozilla.org, as well as because Fox's domain is actually `www.fox.com`. Thus, I just went to http://127.0.0.1:8000/admin/, updated an address's `used_on` field (I set it to `notwww.mozilla.org`), then went and visited a domain that partially matched that value (I visited www.mozilla.org - there's an email field at the bottom of the page).

Without this change, you should see the above mask being listed as used on that site in both the in-page menu, as well as the context menu. With this change, it should not be listed.

This fixes MPP-2073, and is a follow-up to https://github.com/mozilla/fx-private-relay-add-on/pull/373.