### PR TITLE
Fix label data loss

### DIFF
--- a/src/js/relay.firefox.com/get_profile_data.js
+++ b/src/js/relay.firefox.com/get_profile_data.js
@@ -100,9 +100,7 @@
 
     browser.storage.local.set({
       profileID: parseInt(serverProfileData[0].id, 10),
-      settings: {
-        server_storage: serverProfileData[0].server_storage,
-      },
+      server_storage: serverProfileData[0].server_storage,
     });
 
     const siteStorageEnabled = serverProfileData[0].server_storage;

--- a/src/js/relay.firefox.com/settings_refresh.js
+++ b/src/js/relay.firefox.com/settings_refresh.js
@@ -11,6 +11,9 @@
       browser.runtime.sendMessage({
         method: "refreshAccountPages",
       });
+      browser.runtime.sendMessage({
+        method: "getServerStoragePref",
+      });
     }
   });
 })();


### PR DESCRIPTION
Fixes https://github.com/mozilla/fx-private-relay/issues/2098 / MPP-2097.

The fix is small, but took a lot of tracking down. To reproduce,
sign in with an account with server-side label storage enabled and
the add-on installed. Server-side storage can be enabled in `/accounts/settings/`:

![image](https://user-images.githubusercontent.com/4251/177175175-be576505-2b07-4d25-a2da-4cf7dff5dd1d.png)

Make sure there are masks with a label. Then
right-click on an email field; the function `getServerStoragePref`
in background.js should now be setting `server_storage: true` in
the extension's local storage.

Now disable server-side storage, and reload the Relay website.
Now, instead of storing the updated preferences in the correct
place in the extension's storing, it will store it as
`settings: { server_storage: false }`.

Now, in an email field, open the menu from the icon button. It will
now check the `server_storage` property in the extension storage
(which is incorrectly still set to `true`), then re-fetch the masks
from the server, thereby overwriting locally-stored labels.

With this fix, the `server_storage` pref will be stored correctly,
and thus locally-stored labels will no longer be overwritten.