### PR TITLE
Fix local labels disappearing when website updates

### DIFF
--- a/src/js/relay.firefox.com/get_profile_data.js
+++ b/src/js/relay.firefox.com/get_profile_data.js
@@ -44,7 +44,7 @@
     // Get the api token from the account profile page
     const profileMainElement = document.querySelector("#profile-main");
     const apiToken = profileMainElement.dataset.apiToken;
-    browser.storage.local.set({ apiToken });
+    await browser.storage.local.set({ apiToken });
 
     // API URL is ${RELAY_SITE_ORIGIN}/api/v1/
     const { relayApiSource } = await browser.storage.local.get("relayApiSource");
@@ -118,8 +118,8 @@
         : [];
       await browser.storage.local.set({
         relayAddresses:
-          applyLocalLabels(relayAddresses)
-          .concat(applyLocalLabels(domainAddresses)),
+          (await applyLocalLabels(relayAddresses))
+          .concat(await applyLocalLabels(domainAddresses)),
       });
     }
 
@@ -133,14 +133,14 @@
      * we just fetched.
      *
      * @param {RandomMask[]} addresses
-     * @returns {RandomMask[]}
+     * @returns {Promise<RandomMask[]>}
      */
-    function applyLocalLabels(addresses) {
+    async function applyLocalLabels(addresses) {
       if (siteStorageEnabled) {
         return addresses;
       }
 
-      const localAddressCache = browser.storage.local.get("relayAddresses").relayAddresses ?? [];
+      const localAddressCache = (await browser.storage.local.get("relayAddresses")).relayAddresses ?? [];
       return addresses.map(address => {
         const matchingLocalAddress = localAddressCache.find((localAddress) => {
           return (


### PR DESCRIPTION
Fixes #383.

When the website informed the add-on that the list of masks was
updated (e.g. because the user generated a new mask on the
website), the add-on updates its local cache of masks, and tries to
copy over the labels it has stored locally for those masks.
However, the API to retrieve these local labels returns a Promise.
Since that wasn't `await`ed, the local labels were never found, and
then subsequently dropped them when replacing the local mask cache
with the updated mask list from the server.

(And we don't have TypeScript in the add-on that would've warned us about this :slightly_smiling_face: )