### PR TITLE
Ensure website styles are overridden

### DIFF
--- a/src/css/relay-website.css
+++ b/src/css/relay-website.css
@@ -1,11 +1,17 @@
-.is-visible-with-addon {
-    /* !important to ensure this overwrites website styles, regardless of specificity */
-    display: initial !important;
-    visibility: visible !important;
-}
+/*
+    Styles in the `add-on-overrides` layer (which the add-on injects)
+    should override those in the `add-on-overridable` layer.
+*/
+@layer add-on-overridable, add-on-overrides;
 
-.is-hidden-with-addon {
-    /* !important to ensure this overwrites website styles, regardless of specificity */
-    display: none !important;
-    visibility: collapse !important;
+@layer add-on-overrides {
+    .is-visible-with-addon {
+        display: initial;
+        visibility: visible;
+    }
+
+    .is-hidden-with-addon {
+        display: none;
+        visibility: collapse;
+    }
 }

--- a/src/css/relay-website.css
+++ b/src/css/relay-website.css
@@ -1,9 +1,11 @@
 .is-visible-with-addon {
-    display: initial;
-    visibility: visible;
+    /* !important to ensure this overwrites website styles, regardless of specificity */
+    display: initial !important;
+    visibility: visible !important;
 }
 
 .is-hidden-with-addon {
-    display: none;
-    visibility: collapse;
+    /* !important to ensure this overwrites website styles, regardless of specificity */
+    display: none !important;
+    visibility: collapse !important;
 }


### PR DESCRIPTION
**Note: do not release until https://github.com/mozilla/fx-private-relay/pull/2217 is deployed to production!** Alternatively, we can merge and release just commit df84967c403f1631f6e652a398dd68a75ebbd205 to have a fix live now without needing to wait for a website deployment.

Apparently stylesheets injected by extensions in Chrome do not get
injected last, and thus do not necessarily override website styles
with the same specificity. I've updated the website to use an
explicit layer [1], and to have that layer be overridden by the
layer introduced to the add-on in this commit.

[1] https://developer.mozilla.org/en-US/docs/Web/CSS/@layer

How to test: run Chrome locally with the add-on installed (`npm run web-ext-run:chrome`), then visit a locally running server (127.0.0.1, i.e. using `npm run watch`). Upgrade a free account to Premium, then check the last onboarding step. The "Relay extension added!" text and "Go to Dashboard" button should be visible with this change, whereas it isn't in main.

Fixes #385, fixes #310.