### PR TITLE
Create releases when pushing tags

### DIFF
--- a/.github/workflows/sign-and-release-to-github.yml
+++ b/.github/workflows/sign-and-release-to-github.yml
@@ -3,6 +3,8 @@ name: continuous prerelease to GitHub
 on:
   push:
     branches: [ "*" ]
+    # When pushing version number tags (not prefixed with a v):
+    tags: [ "[0-9]+.[0-9]+.[0-9]+" ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The job was there (added in https://github.com/mozilla/fx-private-relay-add-on/pull/382), but it didn't run yet, and therefore the new tag did not build production artefacts yet.