### PR TITLE
Fix broken link in Chrome 2.4.6 release

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -109,7 +109,7 @@
             </figure>
             <h1 class="i18n-content" data-i18n-message-id="popupEndOfIntroPricingHeadline"></h1>
             <p class="i18n-content" data-i18n-message-id="popupEndOfIntroPricingBody"></p>
-            <a class="get-premium-link fx-relay-c-button t-basic i18n-content" data-i18n-message-id="popupEndOfIntroPricingCTA"></a>
+            <a class="close-popup-after-click get-premium-link fx-relay-c-button t-basic i18n-content" data-event-action="click" data-event-label="end-of-intro-pricing-upgrade" data-i18n-message-id="popupEndOfIntroPricingCTA"></a>
           </div>
           <!-- End of End Intro Pricing Panel -->
 


### PR DESCRIPTION
Clicking the Upgrade CTA should take the user to the interstitial page.
https://user-images.githubusercontent.com/13066134/188744745-42df3ae2-d2ca-4547-8b9b-c9cf90fd35c8.mov

