### PR TITLE
Remove references to old Premium plans

### DIFF
--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -95,7 +95,7 @@ async function patchMaskInfo(method = "PATCH", id, data, opts=null) {
 }
 
 async function storeRuntimeData(opts={forceUpdate: false}) {  
-  const existingPremiumAvailability = (await browser.storage.local.get("premiumCountries")).premiumCountries;
+  const existingPremiumAvailability = (await browser.storage.local.get("periodicalPremiumPlans")).periodicalPremiumPlans;
   // If we already fetched Premium availability in the past seven days,
   // don't fetch it again.
   const checkingRemainingDays = Date.now() - 7 * 24 * 60 * 60 * 1000;
@@ -120,10 +120,6 @@ async function storeRuntimeData(opts={forceUpdate: false}) {
   const runtimeData = await runtimeDataResponse.json();
   
   browser.storage.local.set({
-    premiumCountries: {
-      PREMIUM_PLANS: runtimeData.PREMIUM_PLANS,
-      fetchedAt: Date.now(),
-    },
     waffleFlags: {
       WAFFLE_FLAGS: runtimeData.WAFFLE_FLAGS,
       fetchedAt: Date.now(),

--- a/src/js/background/context-menu.js
+++ b/src/js/background/context-menu.js
@@ -436,12 +436,12 @@ const relayContextMenus = {
       canUpgradeToPremium: async () => {
         const { premium } = await browser.storage.local.get("premium");
 
-        const premiumCountryAvailability = (await browser.storage.local.get("premiumCountries")).premiumCountries?.PREMIUM_PLANS
+        const premiumCountryAvailability = (await browser.storage.local.get("periodicalPremiumPlans")).periodicalPremiumPlans?.PERIODICAL_PREMIUM_PLANS
 
         // Note: If user is already premium, this will return false.
         return (
           !premium &&
-          premiumCountryAvailability?.premium_available_in_country === true
+          premiumCountryAvailability?.available_in_country === true
         );
       },
     },

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -439,7 +439,7 @@ const buildContent = {
       const maxNumAliasesReached = numAliasesRemaining <= 0;
 
       // Check if premium features are available
-      const premiumCountryAvailability = (await browser.storage.local.get("premiumCountries")).premiumCountries?.PREMIUM_PLANS;
+      const premiumCountryAvailability = (await browser.storage.local.get("periodicalPremiumPlans")).periodicalPremiumPlans?.PERIODICAL_PREMIUM_PLANS
 
       // Set Generate Mask button
       buildContent.components.setUnlimitedButton(
@@ -797,19 +797,19 @@ const buildContent = {
 
       // If the user cannot upgrade, prompt them to join the waitlist
       const unlimitedTextContent =
-        premiumCountryAvailability?.premium_available_in_country
+        premiumCountryAvailability?.available_in_country
           ? browser.i18n.getMessage("popupGetUnlimitedAliases_mask")
           : browser.i18n.getMessage("pageInputIconJoinPremiumWaitlist");
 
       // If the user cannot upgrade, update the UTM params
       const unlimitedHref =
-        premiumCountryAvailability?.premium_available_in_country
+        premiumCountryAvailability?.available_in_country
           ? `${relaySiteOrigin}/premium?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=get-premium-link`
           : `${relaySiteOrigin}/premium?utm_source=fx-relay-addon&utm_medium=input-menu&utm_content=join-waitlist-link`;
 
       // If the user cannot upgrade, update the GA event ID
       const unlimitedInPageEventId =
-        premiumCountryAvailability?.premium_available_in_country
+        premiumCountryAvailability?.available_in_country
           ? "input-menu-get-premium-btn"
           : "input-menu-join-waitlist-btn";
 

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -320,7 +320,7 @@ async function showRelayPanel(tipPanelToShow) {
   });
 
   //Check if premium features are available
-  const premiumCountryAvailability = (await browser.storage.local.get("premiumCountries"))?.premiumCountries?.PREMIUM_PLANS;
+  const premiumCountryAvailability = (await browser.storage.local.get("periodicalPremiumPlans")).periodicalPremiumPlans?.PERIODICAL_PREMIUM_PLANS
 
   //Check if user is premium
   const { premium } = await browser.storage.local.get("premium");
@@ -386,7 +386,7 @@ async function showRelayPanel(tipPanelToShow) {
       panelStrings = onboardingPanelStrings["maxAliasesPanel"];
       onboardingPanelWrapper.classList = "maxAliasesPanel";
 
-      if (premiumCountryAvailability?.premium_available_in_country === true) {
+      if (premiumCountryAvailability?.available_in_country === true) {
         const upgradeButton = document.querySelector(".upgrade-banner-wrapper");
         upgradeButton.classList.remove("is-hidden");
       }
@@ -405,7 +405,7 @@ async function showRelayPanel(tipPanelToShow) {
     upgradeButtonIconEl.src = panelStrings.upgradeButtonIcon;
 
     //If Premium features are not available, do not show upgrade CTA on the panel
-    if (premiumCountryAvailability?.premium_available_in_country === true) {
+    if (premiumCountryAvailability?.available_in_country === true) {
       const premiumCTA = document.querySelector(".premium-cta");
       premiumCTA.classList.remove("is-hidden");
     }
@@ -471,7 +471,7 @@ async function showRelayPanel(tipPanelToShow) {
     remainingAliasMessage.classList.add("is-hidden");
   }
 
-  if (premiumCountryAvailability?.premium_available_in_country === true) {
+  if (premiumCountryAvailability?.available_in_country === true) {
     getUnlimitedAliases.classList.remove("is-hidden");
   }
 

--- a/src/js/relay.firefox.com/get_profile_data.js
+++ b/src/js/relay.firefox.com/get_profile_data.js
@@ -169,12 +169,6 @@
     const fxaSubscriptionsUrl = document.querySelector(
       "firefox-private-relay-addon-data"
     ).dataset.fxaSubscriptionsUrl;
-    const premiumProdId = document.querySelector(
-      "firefox-private-relay-addon-data"
-    ).dataset.premiumProdId;
-    const premiumPriceId = document.querySelector(
-      "firefox-private-relay-addon-data"
-    ).dataset.premiumPriceId;
     const aliasesUsedVal = document.querySelector(
       "firefox-private-relay-addon-data"
     ).dataset.aliasesUsedVal;
@@ -193,8 +187,6 @@
 
     browser.storage.local.set({
       fxaSubscriptionsUrl,
-      premiumProdId,
-      premiumPriceId,
       aliasesUsedVal,
       emailsForwardedVal,
       emailsBlockedVal,


### PR DESCRIPTION
This removes references to the old `PREMIUM_PLANS`, which will be removed from the API, instead looking at `PERIODICAL_PREMIUM_PLANS` to determine whether Premium is available for a user. (The new object has new plan IDs, grouped by monthly and yearly subscriptions, rather than only the monthly subscription being available.)

I set this PR to target #398, because that already added the new plans to local storage - this also removes the old plan.