### PR TITLE
Fix #403 - Added error catching to getCurrentPageHostname() bg message function to ensure settings options in the pop-up work on internal browser pages

### DIFF
--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -361,7 +361,11 @@ async function displayBrowserActionBadge() {
 browser.runtime.onMessage.addListener(async (m, sender, _sendResponse) => {
   let response;
   const currentPage = await getCurrentPage();
-  const url = new URL(currentPage.url);
+  let url = false;
+
+  if (currentPage.url) {
+    url = new URL(currentPage.url);
+  }
 
   switch (m.method) {
     case "displayBrowserActionBadge":
@@ -389,7 +393,7 @@ browser.runtime.onMessage.addListener(async (m, sender, _sendResponse) => {
       response = await getCurrentPage();
       break;
     case "getCurrentPageHostname":
-      response = url.hostname;
+      if (url) { response = url.hostname }
       break;
     case "makeRelayAddress":
       response = await makeRelayAddress(m.description);

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -361,11 +361,6 @@ async function displayBrowserActionBadge() {
 browser.runtime.onMessage.addListener(async (m, sender, _sendResponse) => {
   let response;
   const currentPage = await getCurrentPage();
-  let url = false;
-
-  if (currentPage.url) {
-    url = new URL(currentPage.url);
-  }
 
   switch (m.method) {
     case "displayBrowserActionBadge":
@@ -393,7 +388,8 @@ browser.runtime.onMessage.addListener(async (m, sender, _sendResponse) => {
       response = await getCurrentPage();
       break;
     case "getCurrentPageHostname":
-      if (url) { response = url.hostname }
+      // Only capture the page hostanme if the active tab is an non-internal (about:) page.
+      if (currentPage.url) { response = (new URL(currentPage.url)).hostname }
       break;
     case "makeRelayAddress":
       response = await makeRelayAddress(m.description);


### PR DESCRIPTION
Fixed #403 

While testing the add-on on another PR, I ran across this edge case. 

To test: 
- Open add-on in either desktop browser
- While on the entry/add-on login page, click the pop-up panel icon
- Go to settings panel
- Click first setting "Show Relay icon in email fields on websites" 
- **Expected:** The setting should toggle off (or back on if off previously) as expected
- Go to a login page and confirm setting works as expected (facebook.com, accounts.spotify.com, etc) 