### PR TITLE
Don't generate .xpi's when pushing a tag

### DIFF
--- a/.github/workflows/sign-and-release-to-github.yml
+++ b/.github/workflows/sign-and-release-to-github.yml
@@ -95,6 +95,7 @@ jobs:
 
       - name: "Sign"
         run: ./node_modules/.bin/web-ext sign -s src --channel=unlisted --api-key=${{ secrets.AMO_API_KEY }} --api-secret=${{ secrets.AMO_API_SECRET }}
+        if: github.ref_type == 'branch'
 
       - name: "Tag"
         run: |
@@ -115,7 +116,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: fx-private-relay-stage-chromium.zip
+          name: fx-private-relay-extension.zip
           path: src/
 
       - name: Mark GitHub Deployment as successful


### PR DESCRIPTION
Generating an XPI will push it to addons.mozilla.org, which will then no longer accept new uploads of that version. Since the .xpi we upload is unlisted, we can't use it as our release.

Instead, just like for Chrome, we'll need to upload the .zip file to AMO.