### PR TITLE
Fix Phone Masking Announcement UI Bugs

### DIFF
--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -347,9 +347,7 @@ async function showRelayPanel(tipPanelToShow) {
     if (panelStrings.longText) {
       educationBodyEl.classList.add("small-font-size");
     }
-
-    const totalPanels = Object.keys(premiumPanelStrings.announcements).length;
-    setPagination(panelId, totalPanels);
+    setPagination(panelId);
 
     educationHeadlineEl.textContent = panelStrings.tipHeadline;
     educationBodyEl.textContent = panelStrings.tipBody;
@@ -375,10 +373,9 @@ async function showRelayPanel(tipPanelToShow) {
     const panelToShow = await choosePanel(panelId, premium, premiumSubdomainSet);
     onboardingPanelWrapper.classList = [panelToShow];
     
-    const totalPanels = Object.keys(onboardingPanelStrings.announcements).length;
     let panelStrings = onboardingPanelStrings.announcements[`${panelToShow}`];
 
-    setPagination(panelId, totalPanels);
+    setPagination(panelId);
 
     // Only show maxAliasesPanel to users where bundle / phone masking is unavailable
     // Otherwise, show Phone masking and Bundle promo
@@ -413,12 +410,16 @@ async function showRelayPanel(tipPanelToShow) {
     return;
   };
 
-  const setPagination = (activePanel, totalPanels) => {
+  const setPagination = (activePanel) => {
     const pagination = onboardingPanelWrapper.querySelector(".onboarding-pagination");
     const prevButton = onboardingPanelWrapper.querySelector(".previous-panel");
     const nextButton = onboardingPanelWrapper.querySelector(".next-panel");
     const totalPanelsEl = document.querySelector(".total-panels");
     // Number of panels available for free users
+    let totalPanels = Object.keys(onboardingPanelStrings.announcements).length;
+    if (premium) {
+      totalPanels = Object.keys(premiumPanelStrings.announcements).length;
+    }
     totalPanelsEl.textContent = totalPanels;
     prevButton.classList.remove("is-invisible");
     nextButton.classList.remove("is-invisible");
@@ -442,8 +443,8 @@ async function showRelayPanel(tipPanelToShow) {
   remainingAliasMessage.textContent = browser.i18n.getMessage("popupRemainingAliases_2_mask", [numRemaining, maxNumAliases]);
   const getUnlimitedAliases = document.querySelector(".premium-cta");
   getUnlimitedAliases.textContent = browser.i18n.getMessage("popupGetUnlimitedAliases_mask");
-
   document.body.classList.add("relay-panel");
+
   updatePremiumPanel(tipPanelToShow);
   updatePanel(numRemaining, tipPanelToShow);
 

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -272,15 +272,15 @@ async function showRelayPanel(tipPanelToShow) {
   // const isBundleAvailableInCountry = (await browser.storage.local.get("bundlePlans")).bundlePlans.BUNDLE_PLANS.available_in_country;
   const isPhoneAvailableInCountry = (await browser.storage.local.get("phonePlans")).phonePlans.PHONE_PLANS.available_in_country;
   
-  const showPhoneMaskingPromo =    await checkWaffleFlag("phones") && isPhoneAvailableInCountry;
-  // TODO: Enable this when bundle pricing has been confirmed
-  // const bundleAvailable =    await checkWaffleFlag("bundle") && isBundleAvailableInCountry;
-  
   // If user has a phone plan, don't show the phone masking promo
   const hasPhone = (await browser.storage.local.get("has_phone")).has_phone;
   
+  const showPhoneMaskingPromo =    await checkWaffleFlag("phones") && isPhoneAvailableInCountry && !hasPhone;
+  // TODO: Enable this when bundle pricing has been confirmed
+  // const bundleAvailable =    await checkWaffleFlag("bundle") && isBundleAvailableInCountry;
+  
   if (
-    showPhoneMaskingPromo && !hasPhone
+    showPhoneMaskingPromo
     // && bundleAvailable
   ) {
     promoElements.forEach(i => {

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -447,7 +447,6 @@ async function showRelayPanel(tipPanelToShow) {
   const getUnlimitedAliases = document.querySelector(".premium-cta");
   getUnlimitedAliases.textContent = browser.i18n.getMessage("popupGetUnlimitedAliases_mask");
   document.body.classList.add("relay-panel");
-
   updatePremiumPanel(tipPanelToShow);
   updatePanel(numRemaining, tipPanelToShow);
 

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -272,12 +272,15 @@ async function showRelayPanel(tipPanelToShow) {
   // const isBundleAvailableInCountry = (await browser.storage.local.get("bundlePlans")).bundlePlans.BUNDLE_PLANS.available_in_country;
   const isPhoneAvailableInCountry = (await browser.storage.local.get("phonePlans")).phonePlans.PHONE_PLANS.available_in_country;
   
-  const phoneMaskingAvailable =    await checkWaffleFlag("phones") && isPhoneAvailableInCountry;
+  const showPhoneMaskingPromo =    await checkWaffleFlag("phones") && isPhoneAvailableInCountry;
   // TODO: Enable this when bundle pricing has been confirmed
   // const bundleAvailable =    await checkWaffleFlag("bundle") && isBundleAvailableInCountry;
-
+  
+  // If user has a phone plan, don't show the phone masking promo
+  const hasPhone = (await browser.storage.local.get("has_phone")).has_phone;
+  
   if (
-    phoneMaskingAvailable 
+    showPhoneMaskingPromo && !hasPhone
     // && bundleAvailable
   ) {
     promoElements.forEach(i => {
@@ -368,7 +371,7 @@ async function showRelayPanel(tipPanelToShow) {
 
   const updatePanel = async (numRemaining, panelId) => {
     // TODO: Add " && bundleAvailable " when bundle pricing has been confirmed
-    const bundlePhoneMaskingAvailable = phoneMaskingAvailable;
+    const bundlePhoneMaskingAvailable = showPhoneMaskingPromo;
     
     const panelToShow = await choosePanel(panelId, premium, premiumSubdomainSet);
     onboardingPanelWrapper.classList = [panelToShow];

--- a/src/js/relay.firefox.com/get_profile_data.js
+++ b/src/js/relay.firefox.com/get_profile_data.js
@@ -101,6 +101,7 @@
     browser.storage.local.set({
       profileID: parseInt(serverProfileData[0].id, 10),
       server_storage: serverProfileData[0].server_storage,
+      has_phone: serverProfileData[0].has_phone
     });
 
     const siteStorageEnabled = serverProfileData[0].server_storage;


### PR DESCRIPTION
This fixes the pagination error on the add on. It should now be displaying the correct number of panels on a premium value for a user not subscribed to phones / is not located in US/CAN.

This PR fixes two tickets -

MPP-2461 (Show the correct number of panels in the pagination bar):
<img width="371" alt="image" src="https://user-images.githubusercontent.com/13066134/195885774-51352abb-3042-4a4a-b305-d911d961d632.png">
How to test:
- With a premium account on a phone plan or a premium account outside of US/CAN, show 4 total panels in the pagination bar.

MPP-2071 (Do not show phone masking announcement to users who have purchased phones)
How to test:
- With an account that has purchased phones, ensure that the add on reverts back to the original state.
