### PR TITLE
Move all fetch() requests to background scripts

### DIFF
--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -25,6 +25,31 @@ browser.runtime.onInstalled.addListener(async (details) => {
   }
 });
 
+async function fetchApiRequest(url, fetchMethod = "GET", body = null, opts=null) {
+  const headers = new Headers();
+
+  const { csrfCookieValue } = await browser.storage.local.get("csrfCookieValue");
+  
+  headers.set("X-CSRFToken", csrfCookieValue);
+  headers.set("Content-Type", "application/json");
+  headers.set("Accept", "application/json");
+
+  if (opts && opts.auth) {
+    const apiToken = await browser.storage.local.get("apiToken");
+    headers.set("Authorization", `Token ${apiToken.apiToken}`);
+  }
+
+  const response = await fetch(url, {
+    mode: "same-origin",
+    method: fetchMethod,
+    headers: headers,
+    body,
+  });
+
+  const answer = await response.json();
+  return answer;
+}
+
 // This function is defined as global in the ESLint config _because_ it is created here:
 // eslint-disable-next-line no-redeclare, no-unused-vars
 async function getAliasesFromServer(method = "GET", opts=null) {
@@ -366,6 +391,14 @@ browser.runtime.onMessage.addListener(async (m, sender, _sendResponse) => {
       break;
     case "iframeCloseRelayInPageMenu":
       browser.tabs.sendMessage(sender.tab.id, {message: "iframeCloseRelayInPageMenu"});
+      break;
+    case "fetchApiRequest": 
+      response = await fetchApiRequest(
+        m.url, 
+        m.fetchMethod,
+        m.body,
+        m.otps
+      );
       break;
     case "fillInputWithAlias":
       browser.tabs.sendMessage(sender.tab.id, m.message);

--- a/src/js/relay.firefox.com/get_profile_data.js
+++ b/src/js/relay.firefox.com/get_profile_data.js
@@ -46,6 +46,24 @@
     const apiToken = profileMainElement.dataset.apiToken;
     await browser.storage.local.set({ apiToken });
 
+    const cookieString =
+    typeof document.cookie === "string" ? document.cookie : "";
+    
+    const cookieStringArray = cookieString
+      .split(";")
+      .map((individualCookieString) => individualCookieString.split("="))
+      .map(([cookieKey, cookieValue]) => [
+        cookieKey.trim(),
+        cookieValue.trim(),
+      ]);
+
+    const [_csrfCookieKey, csrfCookieValue] = cookieStringArray.find(
+      ([cookieKey, _cookieValue]) => cookieKey === "csrftoken"
+    );
+
+    await browser.storage.local.set({ csrfCookieValue: csrfCookieValue });
+
+
     // API URL is ${RELAY_SITE_ORIGIN}/api/v1/
     const { relayApiSource } = await browser.storage.local.get("relayApiSource");
 
@@ -53,50 +71,11 @@
     const relayApiUrlRelayAddresses = `${relayApiSource}/relayaddresses/`;
     const relayApiUrlDomainAddresses = `${relayApiSource}/domainaddresses/`;
 
-    async function apiRequest(url, method = "GET", body = null, opts=null) {
-
-      const cookieString =
-        typeof document.cookie === "string" ? document.cookie : "";
-      const cookieStringArray = cookieString
-        .split(";")
-        .map((individualCookieString) => individualCookieString.split("="))
-        .map(([cookieKey, cookieValue]) => [
-          cookieKey.trim(),
-          cookieValue.trim(),
-        ]);
-
-      const [_csrfCookieKey, csrfCookieValue] = cookieStringArray.find(
-        ([cookieKey, _cookieValue]) => cookieKey === "csrftoken"
-      );
-
-      browser.storage.local.set({ csrfCookieValue: csrfCookieValue });
-
-
-      const headers = new Headers();
-
-
-      headers.set("X-CSRFToken", csrfCookieValue);
-      headers.set("Content-Type", "application/json");
-      headers.set("Accept", "application/json");
-
-      if (opts && opts.auth) {
-        const apiToken = await browser.storage.local.get("apiToken");
-        headers.set("Authorization", `Token ${apiToken.apiToken}`);
-      }
-
-
-      const response = await fetch(url, {
-        mode: "same-origin",
-        method,
-        headers: headers,
-        body,
-      });
-
-      const answer = await response.json();
-      return answer;
-    }
-
-    const serverProfileData = await apiRequest(apiProfileURL);
+    
+    const serverProfileData = await browser.runtime.sendMessage({
+      method: "fetchApiRequest",
+      url: apiProfileURL
+    });
 
     browser.storage.local.set({
       profileID: parseInt(serverProfileData[0].id, 10),
@@ -113,10 +92,17 @@
      * @param {{ fetchCustomMasks?: boolean }} options - Set `fetchCustomMasks` to `true` if the user is a Premium user.
      */
     async function refreshLocalLabelCache(options = {}) {
+      
       /** @type {RandomMask[]} */
-      const relayAddresses = await apiRequest(relayApiUrlRelayAddresses);
+      const relayAddresses = await browser.runtime.sendMessage({
+        method: "fetchApiRequest",
+        url: relayApiUrlRelayAddresses
+      });
       const domainAddresses = options.fetchCustomMasks
-        ? await apiRequest(relayApiUrlDomainAddresses)
+        ? await browser.runtime.sendMessage({
+          method: "fetchApiRequest",
+          url: relayApiUrlDomainAddresses
+        })
         : [];
       await browser.storage.local.set({
         relayAddresses:
@@ -227,7 +213,13 @@
 
         if (body.description.length > 0 || body.generated_for.length > 0 || body.used_on.length > 0) {
           const endpoint = alias.mask_type === "custom" ? relayApiUrlDomainAddresses : relayApiUrlRelayAddresses;
-          await apiRequest(`${endpoint}${alias.id}/`, "PATCH", JSON.stringify(body), {auth: true});
+          await browser.runtime.sendMessage({
+            method: "fetchApiRequest",
+            url: `${endpoint}${alias.id}/`,
+            fetchMethod: "PATCH",
+            body: JSON.stringify(body),
+            opts: {auth: true}
+          });
         }
       }
     }
@@ -249,9 +241,17 @@
     if (siteStorageEnabled) {
       // Sync alias data from server page.
       // If local storage items exist AND have label metadata stored, sync it to the server.
-      const serverRelayAddresses = await apiRequest(relayApiUrlRelayAddresses);
+      
+      const serverRelayAddresses = await browser.runtime.sendMessage({
+        method: "fetchApiRequest",
+        url: relayApiUrlRelayAddresses
+      });
+      
       const serverDomainAddresses = isPremiumUser
-        ? await apiRequest(relayApiUrlDomainAddresses)
+        ? await browser.runtime.sendMessage({
+          method: "fetchApiRequest",
+          url: relayApiUrlDomainAddresses
+        })
         : [];
 
       // let usage: This data may be overwritten when merging the local storage dataset with the server set.


### PR DESCRIPTION
### Summary: 
This is part of a pre-migration to Manifest v3. The only content script where `fetch()` requests were happening was in the `get_profile_data.js` script, which [only runs on the `/accounts/profile/*` pages](https://github.com/mozilla/fx-private-relay-add-on/blob/main/src/manifest.json#L55-L60). 

**Links**: 
- See #416 for more context
- Related: [MPP-2505](https://mozilla-hub.atlassian.net/browse/MPP-2505)


### Testing:

* Run on add-on, log in/sign up for Relay account
* Expected: All data for the add-on is gathered as normal from the homepage without any breakage

⚠️  Be sure to test with both free / premium accounts with privacy/label storage toggled on and off. (4 possible test scenarios) 