### PR TITLE
Add Manfiest v3 preview build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "remove-locales-github": "rm -rf src/_locales/.github",
     "web-ext-run": "npm run remove-locales-github && web-ext run -s src/",
     "web-ext-run:firefox": "npm run web-ext-run -- --target firefox-desktop",
+    "web-ext-run:firefox-mv3": "npm run web-ext-run -- --firefox-preview --pref=extensions.eventPages.enabled=true --verbose",
     "web-ext-run:android": "npm run web-ext-run -- --target firefox-android --adb-device $npm_config_device --firefox-apk org.mozilla.fenix",
     "web-ext-run:chrome": "npm run web-ext-run -- --target chromium",
     "web-ext-run:desktop": "npm run web-ext-run -- --target chromium --target firefox-desktop"


### PR DESCRIPTION
### Summary: 
This is a useful tool for running Manifest v3 previews in Firefox. 

**Links**: 
- See #416 for more context
- Related: [MPP-2505](https://mozilla-hub.atlassian.net/browse/MPP-2505)


### Testing

No testing steps