### PR TITLE
Add custom dimension to distinguish add-on telemetry from website traffic

### DIFF
--- a/src/js/shared/metrics.js
+++ b/src/js/shared/metrics.js
@@ -6,6 +6,8 @@
 async function sendRelayEvent(eventCategory, eventAction, eventLabel) {
   // "dimension5" is a Google Analytics-specific variable to track a custom dimension. 
   // This dimension is used to determine which browser vendor the add-on is using: Firefox or Chrome
+  // "dimension7" is a Google Analytics-specific variable to track a custom dimension,
+  // used to determine where the ping is coming from: website, add-on or app
   return await browser.runtime.sendMessage({
     method: "sendMetricsEvent",
     eventData: {
@@ -13,6 +15,7 @@ async function sendRelayEvent(eventCategory, eventAction, eventLabel) {
       action: eventAction,
       label: eventLabel,
       dimension5: await getBrowser(),
+      dimension7: "add-on",
     },
   });
 }


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes [MPP-2582](https://mozilla-hub.atlassian.net/browse/MPP-2582)
Companion PR: https://github.com/mozilla/fx-private-relay/pull/2810

How to test:
- Open add-on, log in
- Open about:debugging and view network requests from the add-on
- Click pop-up button
- **Expected:** A network event, `metrics-event`, should fire. View the request and there should be a 
```
dimension7: "add-on"
```
---

- [X] ~l10n changes have been submitted to the l10n repository, if any.~
- [X] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
