### PR TITLE
Ensure the mask filter match count is consistent

### DIFF
--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -852,27 +852,13 @@ const buildContent = {
           ".fx-relay-menu-masks-search-input"
         );
 
-        const searchFilterTotal = document.querySelector(
-          ".js-filter-masks-total"
-        );
-
-        const searchFilterVisible = document.querySelector(
-          ".js-filter-masks-visible"
-        );
-
-        const maskSearchResults = document.querySelectorAll(
-          ".fx-relay-menu-masks-list.is-visible ul li"
-        );
-
-        searchFilterTotal.textContent = maskSearchResults.length;
-        searchFilterVisible.textContent = maskSearchResults.length;
-
         // Resize iframe
         await browser.runtime.sendMessage({
           method: "updateIframeHeight",
           height: document.getElementById("fxRelayMenuBody").scrollHeight,
         });
 
+        applySearchFilter(filterSearchInput.value);
         filterSearchInput.focus();
       },
       init: async () => {


### PR DESCRIPTION
This PR fixes MPP-2639.

When switching tabs in the in-page menu (between "From this website" and "All email masks"), the search counter would be newly initialised — even though a filter my still be active.

With this change, the filter will also be applied when switching tabs, and with it, the correct count will be initialised.

How to test: sign in to an account with more than five masks, and open the in-page menu on a page for which at least one mask has specifically been generated. Switch to the "All email masks" tab, and filter the masks. Then switch to "From this website" and back - the count should not say 6/6.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
