### PR TITLE
MPP-2634 - Do not display negative masks in popup

### DIFF
--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -464,10 +464,17 @@ async function showRelayPanel(tipPanelToShow) {
   const { relayAddresses, maxNumAliases } = await getRemainingAliases();
   const numRemaining = maxNumAliases - relayAddresses.length;
   const remainingAliasMessage = document.querySelector(".aliases-remaining");
-  remainingAliasMessage.textContent = browser.i18n.getMessage("popupRemainingAliases_2_mask", [numRemaining, maxNumAliases]);
   const getUnlimitedAliases = document.querySelector(".premium-cta");
   getUnlimitedAliases.textContent = browser.i18n.getMessage("popupGetUnlimitedAliases_mask");
   document.body.classList.add("relay-panel");
+  
+  // Prevent negative masks from showing, default to 0 if all free masks have been used up
+  let positiveNumRemaining = numRemaining;
+  if (numRemaining <= 0) {
+    positiveNumRemaining = 0;
+  }
+  remainingAliasMessage.textContent = browser.i18n.getMessage("popupRemainingAliases_2_mask", [positiveNumRemaining, maxNumAliases]);
+  
   updatePremiumPanel(tipPanelToShow);
   updatePanel(numRemaining, tipPanelToShow);
 


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #MPP-2634 

How to test:
With a downgraded account or an account that displays negative masks, check that if the user has no free masks left that the number is kept at 0.

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
