### PR TITLE
Adjust privacy policy link to go directly to Firefox Relay section

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -40,7 +40,7 @@
           <!-- Settings Redirect -->
           <li class="setting flex-col">
             <a id="popupSettingsLeaveFeedbackLink" href="https://addons.mozilla.org/firefox/addon/private-relay/?utm_source=fx-relay-addon&utm_medium=popup" class="setting-label setting-link close-popup-after-click i18n-content" data-event-action="click" data-event-label="panel-leave-feedback-link" data-i18n-message-id="popupSettingsLeaveFeedback"></a>
-            <a href="https://www.mozilla.org/privacy/firefox-relay/?utm_source=fx-relay-addon&utm_medium=popup" class="setting-label setting-link close-popup-after-click i18n-content" data-event-action="click" data-event-label="panel-privacy-link" data-i18n-message-id="popupSettingsPrivacy"></a>
+            <a href="https://www.mozilla.org/privacy/firefox-relay/?utm_source=fx-relay-addon&utm_medium=popup#relay" class="setting-label setting-link close-popup-after-click i18n-content" data-event-action="click" data-event-label="panel-privacy-link" data-i18n-message-id="popupSettingsPrivacy"></a>
             <a href="https://www.mozilla.org/about/legal/terms/firefox-relay/?utm_source=fx-relay-addon&utm_medium=popup" class="setting-label setting-link close-popup-after-click i18n-content" data-event-action="click" data-event-label="panel-terms-of-service" data-i18n-message-id="popupSettingsTermsOfService"></a>
             <!-- Report Issue Panel Prompt -->
             <a class="setting-label setting-link settings-report-issue i18n-content" data-event-action="click"
@@ -222,7 +222,7 @@
             <div class="newsflash-description">
               <h1 class="newsflash-headline i18n-content" data-i18n-message-id="popupPrivacyNoticeUpdateHeadline"></h1>
               <p class="newsflash-body i18n-content" data-i18n-message-id="popupPrivacyNoticeUpdateBody"></p>
-              <a class="newsflash-learn-more i18n-content" href="https://www.mozilla.org/privacy/firefox-relay/?utm_source=fx-relay-addon&utm_medium=popup&utm_content=privacy-notice-update-notification" data-i18n-message-id="popupPrivacyNoticeUpdateButtonLearnMore"></a>
+              <a class="newsflash-learn-more i18n-content" href="https://www.mozilla.org/privacy/firefox-relay/?utm_source=fx-relay-addon&utm_medium=popup&utm_content=privacy-notice-update-notification#relay" data-i18n-message-id="popupPrivacyNoticeUpdateButtonLearnMore"></a>
               <div class="newsflash-buttons">
                 <button class="js-button-dismiss newsflash-button-dismiss newsflash-button i18n-content" data-i18n-message-id="popupPrivacyNoticeUpdateButtonDismiss"></button>
               </div>


### PR DESCRIPTION
## Summary

Chrome is rejecting our submissions because of a privacy policy issue: 

<img width="496" alt="Screen Shot 2023-01-06 at 9 54 27 AM" src="https://user-images.githubusercontent.com/2692333/211048461-f9705cab-03d2-43be-b6a6-147c7577be97.png">

Links from screenshot: 
- [Purple Nickel](https://developer.chrome.com/docs/webstore/troubleshooting/#udp-prominent-disclosure)
- [Relevant Section / Learn More](https://developer.chrome.com/webstore/program_policies#userdata)
- [Contact / Learn More](https://support.google.com/chrome_webstore/contact/one_stop_support)

## Testing

- Open add-on (Logged in or Logged out)
- Click ⚙️ > Privacy
- Expected: Privacy police page on mozilla.org should open to Firefox Relay section 

### Checklist

- [x] ~l10n changes have been submitted to the l10n repository, if any.~
- [x] ~All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).~
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
