### PR TITLE
[MPP-1714] Popup Refactor - Stats Panel

### DIFF
--- a/src/css/popup-new.css
+++ b/src/css/popup-new.css
@@ -396,6 +396,7 @@ sign-up-panel::after {
   padding: var(--spacingXs) var(--spacingLg);
   font-size: 14px;
   background: var(--colorWhite);
+  margin-bottom: var(--spacingMd);
 }
 
 .dashboard-stats-list ul {

--- a/src/css/popup-new.css
+++ b/src/css/popup-new.css
@@ -406,11 +406,6 @@ sign-up-panel::after {
   flex-direction: column;
 }
 
-.dashboard-stats-list li {
-  /* border: 1px solid red; */
-}
-
-
 .dashboard-stats-list li:first-child {
   font-weight: 600;
   color: var(--colorBlack)
@@ -426,7 +421,6 @@ sign-up-panel::after {
   flex-direction: row;
   justify-content: space-between;
   padding: var(--spacingMd) 0;
-  /* outline: 1px solid red; */
 }
 
 .dashboard-info + .dashboard-info {
@@ -435,9 +429,10 @@ sign-up-panel::after {
 
 .dashboard-info::before {
   content: "";
+  /* Custom size/positioning for icon on the stat row  */
   width: 20px; 
   height: 20px;
-  margin-left: -25px;
+  margin-left: -25px; 
   position: absolute;
   background-repeat: no-repeat;
   background-color: rgba(0, 0, 0, 0);

--- a/src/css/popup-new.css
+++ b/src/css/popup-new.css
@@ -388,3 +388,74 @@ sign-up-panel::after {
   cursor: pointer;
   color: var(--colorInformational);
 }
+
+/* Stats */
+.dashboard-stats-list {
+  width: 100%;
+  border-radius: var(--borderRadiusSm);
+  padding: var(--spacingXs) var(--spacingLg);
+  font-size: 14px;
+  background: var(--colorWhite);
+}
+
+.dashboard-stats-list ul {
+  list-style-type: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacingMd);
+}
+
+.dashboard-stats-list li {
+  /* border: 1px solid red; */
+}
+
+.dashboard-info-spacer {
+  background-color: var(--colorGrey10);
+  height: 1px;
+}
+
+.dashboard-stats-list li:first-child {
+  font-weight: 600;
+  color: var(--colorBlack)
+}
+
+.dashboard-stats-list li:not(:first-child){
+  padding-left: var(--spacingLg);
+  color: var(--colorGrey50)
+}
+
+.dashboard-info {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.dashboard-info::before {
+  content: "";
+  width: 20px; 
+  height: 20px;
+  margin-left: -25px;
+  position: absolute;
+  background-repeat: no-repeat;
+  background-color: rgba(0, 0, 0, 0);
+  transition: opacity 0.2s ease;
+}
+
+.dashboard-info-emails-blocked::before {
+  background-image: url("/icons/blocked-icon.svg");
+}
+
+.dashboard-info-emails-forwarded::before {
+  background-image: url("/icons/forward-icon.svg");
+}
+
+.dashboard-info-trackers-removed::before {
+  background-image: url("/icons/email-trackers-icon.svg");
+}
+
+.dashboard-stats {
+  right: 0;
+  display: flex;
+  align-items: right;
+}

--- a/src/css/popup-new.css
+++ b/src/css/popup-new.css
@@ -393,7 +393,7 @@ sign-up-panel::after {
 .dashboard-stats-list {
   width: 100%;
   border-radius: var(--borderRadiusSm);
-  padding: var(--spacingXs) var(--spacingLg);
+  padding: 0 var(--spacingLg);
   font-size: 14px;
   background: var(--colorWhite);
   margin-bottom: var(--spacingMd);
@@ -404,17 +404,12 @@ sign-up-panel::after {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--spacingMd);
 }
 
 .dashboard-stats-list li {
   /* border: 1px solid red; */
 }
 
-.dashboard-info-spacer {
-  background-color: var(--colorGrey10);
-  height: 1px;
-}
 
 .dashboard-stats-list li:first-child {
   font-weight: 600;
@@ -430,6 +425,12 @@ sign-up-panel::after {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  padding: var(--spacingMd) 0;
+  /* outline: 1px solid red; */
+}
+
+.dashboard-info + .dashboard-info {
+  border-top: 1px solid var(--colorGrey10);
 }
 
 .dashboard-info::before {

--- a/src/js/popup/popup-new.js
+++ b/src/js/popup/popup-new.js
@@ -90,6 +90,11 @@
             }, false)
             
             break;
+          case "stats":
+            sendRelayEvent("Panel", "click", "opened-stats");
+            popup.panel.stats.init();
+            break;
+
           case "webcompat":
             sendRelayEvent("Panel", "click", "opened-report-issue");
             popup.panel.webcompat.init();
@@ -97,6 +102,27 @@
 
           default:
             break;
+        }
+      },
+      stats: {
+        init: async ()=> {
+            //Get profile data from site
+            const { aliasesUsedVal } = await browser.storage.local.get("aliasesUsedVal");
+            const { emailsForwardedVal } = await browser.storage.local.get("emailsForwardedVal");
+            const { emailsBlockedVal } = await browser.storage.local.get("emailsBlockedVal");
+            const { emailTrackersRemovedVal } = await browser.storage.local.get("emailTrackersRemovedVal");
+
+            const statSet = document.querySelector(".dashboard-stats-list");
+            
+            const aliasesUsedValEl = statSet.querySelector(".aliases-used");
+            const emailsBlockedValEl = statSet.querySelector(".emails-blocked");
+            const emailsForwardedValEl = statSet.querySelector(".emails-forwarded");
+            const emailTrackersRemovedValEl = statSet.querySelector(".email-trackers-removed");
+
+            aliasesUsedValEl.textContent = aliasesUsedVal;
+            emailsBlockedValEl.textContent = emailsBlockedVal;
+            emailsForwardedValEl.textContent = emailsForwardedVal;
+            emailTrackersRemovedValEl.textContent = emailTrackersRemovedVal;
         }
       },
       webcompat: {

--- a/src/js/popup/popup-new.js
+++ b/src/js/popup/popup-new.js
@@ -154,27 +154,27 @@
                   popup.utilities.hasMaskBeenUsedOnCurrentSite(mask, currentPageHostName)
               );
 
-              let currenWebsiteForwardedVal = 0;
-              let currenWebsiteBlockedVal = 0;
+              let currentWebsiteForwardedVal = 0;
+              let currentWebsiteBlockedVal = 0;
 
               filteredMasks.forEach(mask => {
-                currenWebsiteForwardedVal += mask.num_forwarded;
-                currenWebsiteBlockedVal += mask.num_blocked;
+                currentWebsiteForwardedVal += mask.num_forwarded;
+                currentWebsiteBlockedVal += mask.num_blocked;
               });
 
-              const currenWebsiteAliasesUsedValEl = currentWebsiteStateSet.querySelector(".aliases-used");
-              currenWebsiteAliasesUsedValEl.textContent = filteredMasks.length;
+              const currentWebsiteAliasesUsedValEl = currentWebsiteStateSet.querySelector(".aliases-used");
+              currentWebsiteAliasesUsedValEl.textContent = filteredMasks.length;
 
-              const currenWebsiteEmailsForwardedValEl = currentWebsiteStateSet.querySelector(".emails-forwarded");
-              currenWebsiteEmailsForwardedValEl.textContent = currenWebsiteForwardedVal;
+              const currentWebsiteEmailsForwardedValEl = currentWebsiteStateSet.querySelector(".emails-forwarded");
+              currentWebsiteEmailsForwardedValEl.textContent = currentWebsiteForwardedVal;
                             
-              const currenWebsiteEmailsBlockedValEl = currentWebsiteStateSet.querySelector(".emails-blocked");
-              currenWebsiteEmailsBlockedValEl.textContent = currenWebsiteBlockedVal
+              const currentWebsiteEmailsBlockedValEl = currentWebsiteStateSet.querySelector(".emails-blocked");
+              currentWebsiteEmailsBlockedValEl.textContent = currentWebsiteBlockedVal
 
-              const currenWebsiteEmailsBlocked = currentWebsiteStateSet.querySelector(".dashboard-info-emails-blocked");
-              const currenWebsiteEmailsForwarded = currentWebsiteStateSet.querySelector(".dashboard-info-emails-forwarded");
-              currenWebsiteEmailsBlocked.classList.remove("is-hidden");
-              currenWebsiteEmailsForwarded.classList.remove("is-hidden");              
+              const currentWebsiteEmailsBlocked = currentWebsiteStateSet.querySelector(".dashboard-info-emails-blocked");
+              const currentWebsiteEmailsForwarded = currentWebsiteStateSet.querySelector(".dashboard-info-emails-forwarded");
+              currentWebsiteEmailsBlocked.classList.remove("is-hidden");
+              currentWebsiteEmailsForwarded.classList.remove("is-hidden");              
             }
         }
       },

--- a/src/popup-new.html
+++ b/src/popup-new.html
@@ -189,10 +189,10 @@
           </header>
 
           <div class="fx-relay-panel-content">
-            <div class="dashboard-stats-list">
+            <div class="dashboard-stats-list global-stats">
               <ul>
                 <li class="dashboard-info">
-                  <span class="aliases-used-text i18n-content" data-i18n-message-id="popupAliasesUsed_mask"></span>
+                  <span class="aliases-used-text i18n-content" data-i18n-message-id="popupTotalMasksUsed"></span>
                   <div class="dashboard-stats aliases-used"></div>
                 </li>
                 <li class="dashboard-info-spacer"></li>
@@ -205,12 +205,36 @@
                   <span class="emails-forwarded-text i18n-content" data-i18n-message-id="popupEmailsForwarded"></span>
                   <div class="dashboard-stats emails-forwarded"></div>
                 </li>
-                <li class="dashboard-info-spacer"></li>
+                <!-- <li class="dashboard-info-spacer"></li>
                 <li class="dashboard-info dashboard-info-trackers-removed">
                   <span class="email-trackers-removed-text i18n-content"
                     data-i18n-message-id="popupEmailTrackersRemoved"></span>
                   <div class="dashboard-stats email-trackers-removed"></div>
+                </li> -->
+              </ul>
+            </div>
+            <div class="dashboard-stats-list current-website-stats">
+              <ul>
+                <li class="dashboard-info">
+                  <span class="aliases-used-text i18n-content" data-i18n-message-id="popupMasksUsedInThisWebsite"></span>
+                  <div class="dashboard-stats aliases-used">0</div>
                 </li>
+                <li class="dashboard-info-spacer"></li>
+                <li class="dashboard-info dashboard-info-emails-blocked">
+                  <span class="emails-blocked-text i18n-content" data-i18n-message-id="popupEmailsBlocked"></span>
+                  <div class="dashboard-stats emails-blocked">0</div>
+                </li>
+                <li class="dashboard-info-spacer"></li>
+                <li class="dashboard-info dashboard-info-emails-forwarded">
+                  <span class="emails-forwarded-text i18n-content" data-i18n-message-id="popupEmailsForwarded"></span>
+                  <div class="dashboard-stats emails-forwarded">0</div>
+                </li>
+                <!-- <li class="dashboard-info-spacer"></li>
+                <li class="dashboard-info dashboard-info-trackers-removed">
+                  <span class="email-trackers-removed-text i18n-content"
+                    data-i18n-message-id="popupEmailTrackersRemoved"></span>
+                  <div class="dashboard-stats email-trackers-removed">0</div>
+                </li> -->
               </ul>
             </div>
           </div>

--- a/src/popup-new.html
+++ b/src/popup-new.html
@@ -195,22 +195,14 @@
                   <span class="aliases-used-text i18n-content" data-i18n-message-id="popupTotalMasksUsed"></span>
                   <div class="dashboard-stats aliases-used"></div>
                 </li>
-                <li class="dashboard-info-spacer"></li>
                 <li class="dashboard-info dashboard-info-emails-blocked">
                   <span class="emails-blocked-text i18n-content" data-i18n-message-id="popupEmailsBlocked"></span>
                   <div class="dashboard-stats emails-blocked"></div>
                 </li>
-                <li class="dashboard-info-spacer"></li>
                 <li class="dashboard-info dashboard-info-emails-forwarded">
                   <span class="emails-forwarded-text i18n-content" data-i18n-message-id="popupEmailsForwarded"></span>
                   <div class="dashboard-stats emails-forwarded"></div>
                 </li>
-                <!-- <li class="dashboard-info-spacer"></li>
-                <li class="dashboard-info dashboard-info-trackers-removed">
-                  <span class="email-trackers-removed-text i18n-content"
-                    data-i18n-message-id="popupEmailTrackersRemoved"></span>
-                  <div class="dashboard-stats email-trackers-removed"></div>
-                </li> -->
               </ul>
             </div>
             <div class="dashboard-stats-list current-website-stats">
@@ -219,13 +211,11 @@
                   <span class="aliases-used-text i18n-content" data-i18n-message-id="popupMasksUsedInThisWebsite"></span>
                   <div class="dashboard-stats aliases-used">0</div>
                 </li>
-                <li class="dashboard-info-spacer"></li>
-                <li class="dashboard-info dashboard-info-emails-blocked">
+                <li class="dashboard-info dashboard-info-emails-blocked is-hidden">
                   <span class="emails-blocked-text i18n-content" data-i18n-message-id="popupEmailsBlocked"></span>
                   <div class="dashboard-stats emails-blocked">0</div>
                 </li>
-                <li class="dashboard-info-spacer"></li>
-                <li class="dashboard-info dashboard-info-emails-forwarded">
+                <li class="dashboard-info dashboard-info-emails-forwarded is-hidden">
                   <span class="emails-forwarded-text i18n-content" data-i18n-message-id="popupEmailsForwarded"></span>
                   <div class="dashboard-stats emails-forwarded">0</div>
                 </li>

--- a/src/popup-new.html
+++ b/src/popup-new.html
@@ -187,6 +187,34 @@
             <!-- Panel Title -->
             <h2 class="fx-relay-panel-header-title">Stats</h2>
           </header>
+
+          <div class="fx-relay-panel-content">
+            <div class="dashboard-stats-list">
+              <ul>
+                <li class="dashboard-info">
+                  <span class="aliases-used-text i18n-content" data-i18n-message-id="popupAliasesUsed_mask"></span>
+                  <div class="dashboard-stats aliases-used"></div>
+                </li>
+                <li class="dashboard-info-spacer"></li>
+                <li class="dashboard-info dashboard-info-emails-blocked">
+                  <span class="emails-blocked-text i18n-content" data-i18n-message-id="popupEmailsBlocked"></span>
+                  <div class="dashboard-stats emails-blocked"></div>
+                </li>
+                <li class="dashboard-info-spacer"></li>
+                <li class="dashboard-info dashboard-info-emails-forwarded">
+                  <span class="emails-forwarded-text i18n-content" data-i18n-message-id="popupEmailsForwarded"></span>
+                  <div class="dashboard-stats emails-forwarded"></div>
+                </li>
+                <li class="dashboard-info-spacer"></li>
+                <li class="dashboard-info dashboard-info-trackers-removed">
+                  <span class="email-trackers-removed-text i18n-content"
+                    data-i18n-message-id="popupEmailTrackersRemoved"></span>
+                  <div class="dashboard-stats email-trackers-removed"></div>
+                </li>
+              </ul>
+            </div>
+          </div>
+          
         </stats-panel>
 
         <!-- Panel: News -->


### PR DESCRIPTION
## Summary

Links:
- Jira Ticket: https://mozilla-hub.atlassian.net/browse/MPP-1715
- Blocked by #457 
- L10N PR: https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n/pull/44
- Epic PR #456 

TODO:
- [x] Add web page specific stats, logic to compute
- [x] Add logic to handle if there are no webpage specific stats
- [x] Remove "Trackers Blocked" stats
- [x] Add logic to also grab custom masks if premium

## Testing

_Testing Note: I ran `npm run config:prod`_ to get access to sites with actual blocked/forwarded data to test. 

1. Confirm global stats
- Run add-on
- Log in
  - Make note of global stats when logged in
- Open popup, click Stats icon
- **Expected:** Stats should match global totals from dashboard
- If on website with known data, there should be a second dashboard with totals.

1. Confirm website stats
- Run add-on
- Log in
  - Make note of global stats when logged in
- Go to any website with login (Imgur, Facebook, etc) 
- Use add-on to generate random mask
- Open popup click Stats icon
  - _(while active tab is the same site you created generate mask)_
- **Expected:** Stats should have TWO stat blocks. One for global, one for website where mask was created
- If on website with known data, there should be a second dashboard with totals.


## Screenshots

If site has no associated masks: 
<img width="387" alt="image" src="https://user-images.githubusercontent.com/2692333/214390351-3506d512-a85e-4794-a330-f0b819733377.png">

If site has associated masks: 
<img width="382" alt="image" src="https://user-images.githubusercontent.com/2692333/214390430-e22d50fa-7472-4ba8-82bb-ff794cbd23be.png">


