### PR TITLE
[MPP-1914 Popup Refactor - Hide Manage Mask Panel Toggle

### DIFF
--- a/src/css/popup-new.css
+++ b/src/css/popup-new.css
@@ -788,6 +788,12 @@ sign-up-panel::after {
   gap: var(--spacingMd);
 }
 
+.fx-relay-mask-item-address-wrapper {
+  display: flex;
+  gap: var(--spacingXs);
+  flex-direction: column;
+}
+
 .fx-relay-mask-item-address {
   user-select: all;
   font-size: 16px;

--- a/src/js/popup/popup-new.js
+++ b/src/js/popup/popup-new.js
@@ -571,6 +571,12 @@
               maskListItemNewMaskCreatedLabel.textContent = browser.i18n.getMessage("labelMaskCreated");
               maskListItemNewMaskCreatedLabel.classList.add("fx-relay-mask-item-new-mask-created");
               maskListItem.appendChild(maskListItemNewMaskCreatedLabel);
+              
+              const maskListItemAddressBar = document.createElement("div");
+              maskListItemAddressBar.classList.add("fx-relay-mask-item-address-bar");
+
+              const maskListItemAddressWrapper = document.createElement("div");
+              maskListItemAddressWrapper.classList.add("fx-relay-mask-item-address-wrapper");
 
               const maskListItemLabel = document.createElement("span");
               maskListItemLabel.classList.add("fx-relay-mask-item-label");
@@ -578,16 +584,16 @@
               
               // Append Label if it exists
               if (mask.description !== "") {
-                maskListItem.appendChild(maskListItemLabel);
+                maskListItemAddressWrapper.appendChild(maskListItemLabel);
               }
               
-              const maskListItemAddressBar = document.createElement("div");
-              maskListItemAddressBar.classList.add("fx-relay-mask-item-address-bar");
-
               const maskListItemAddress = document.createElement("div");
               maskListItemAddress.classList.add("fx-relay-mask-item-address");
               maskListItemAddress.textContent = mask.full_address;
-              maskListItemAddressBar.appendChild(maskListItemAddress);
+              maskListItemAddressWrapper.appendChild(maskListItemAddress);
+
+              // Add Mask Address Bar Contents 
+              maskListItemAddressBar.appendChild(maskListItemAddressWrapper);
 
               const maskListItemAddressActions = document.createElement("div");
               maskListItemAddressActions.classList.add("fx-relay-mask-item-address-actions");
@@ -620,7 +626,8 @@
               maskListItemToggleButton.setAttribute("data-mask-type", mask.mask_type);
               maskListItemToggleButton.setAttribute("data-mask-address", mask.full_address);
 
-              maskListItemAddressActions.appendChild(maskListItemToggleButton);
+              // TODO: Add toggle button back
+              // maskListItemAddressActions.appendChild(maskListItemToggleButton);
 
               maskListItemAddressBar.appendChild(maskListItemAddressActions);
               maskListItem.appendChild(maskListItemAddressBar);


### PR DESCRIPTION
## Summary

This PR _hides_ the expand button previously added. This feature (managing your masks from the popup) is being delayed to P2. 

Links:
- Jira Tickets:
  - https://mozilla-hub.atlassian.net/browse/MPP-1914
- L10N PR: https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n/pull/44
- Epic PR #456 

## Testing

- TBD

## Screenshots

<img width="400" alt="image" src="https://user-images.githubusercontent.com/2692333/217937618-0179d3d8-b29b-4258-8045-34eec7c20243.png">

