### PR TITLE
[MPP-1708] Popup Refactor - Add-on QA Fixes

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -366,6 +366,12 @@ sign-up-panel::after {
   cursor: pointer;
 }
 
+.fx-relay-settings-link.is-disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
 .fx-relay-settings-link:hover,
 .fx-relay-settings-link:focus {
   background-color: var(--colorViolet05);

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -366,12 +366,6 @@ sign-up-panel::after {
   cursor: pointer;
 }
 
-.fx-relay-settings-link.is-disabled {
-  opacity: 0.5;
-  pointer-events: none;
-  cursor: not-allowed;
-}
-
 .fx-relay-settings-link:hover,
 .fx-relay-settings-link:focus {
   background-color: var(--colorViolet05);

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -392,16 +392,9 @@
         init: async () => {
           
           const masks = await popup.utilities.getMasks();
-          
-          // If no masks are created, 
-          if (masks.length === 0) {
-            const noMasksCreatedPanel = document.querySelector(".fx-relay-no-masks-created");
-            noMasksCreatedPanel.classList.remove("is-hidden");
-          }
-          
+          const generateRandomMask = document.querySelector(".js-generate-random-mask");
           const { premium } = await browser.storage.local.get("premium");
           const maskPanel = document.getElementById("masks-panel");
-          const generateRandomMask = document.querySelector(".js-generate-random-mask");
           
           if (!premium) {
             await popup.panel.masks.utilities.setRemainingMaskCount();
@@ -420,7 +413,6 @@
               const registerSubdomainButton = document.querySelector(".fx-relay-regsiter-subdomain-button");
               registerSubdomainButton.classList.remove("is-hidden");
             } else {
-
               const generateCustomMask = document.querySelector(".js-generate-custom-mask");
               
               // Show "Generate custom mask" button
@@ -441,9 +433,17 @@
               popup.events.generateMask(e, "random");
             }, false);
           
+
+          // If no masks are created, show onboarding prompt
+          if (masks.length === 0) {
+            const noMasksCreatedPanel = document.querySelector(".fx-relay-no-masks-created");
+            noMasksCreatedPanel.classList.remove("is-hidden");
+          }
+
           // Build initial list
           // Note: If premium, buildMasksList runs `popup.panel.masks.search.init()` after completing
           popup.panel.masks.utilities.buildMasksList();
+        
 
           // Remove loading state
           document.body.classList.remove("is-loading");
@@ -518,8 +518,6 @@
               searchForm.classList.add("is-visible");
               searchInput.focus();
             }
-
-            
           },
           reset: () => {
             const searchInput = document.querySelector(".fx-relay-masks-search-input");
@@ -656,6 +654,14 @@
               }, 1000);
             }
 
+            // If user has no masks created, focus on random gen button
+            if (masks.length === 0) {
+              const generateRandomMask = document.querySelector(".js-generate-random-mask");
+              generateRandomMask.focus();
+              return;
+            }
+
+            // If premium, focus on search instead
             if (premium) {
               popup.panel.masks.search.init();
             }

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -267,6 +267,12 @@
         document.body.classList.remove("is-loading");
       }
 
+      // Remove news nav link if there's no news items to display to user
+      if (state.newsContent.length === 0 ) {
+        document.querySelector(".fx-relay-menu-dashboard-link[data-panel-id='news']").remove();
+        return;
+      }
+
       // Set External Event Listerners
       await popup.utilities.setExternalLinkEventListeners();
 
@@ -725,7 +731,7 @@
           const newsList = document.querySelector(".fx-relay-news");
 
           // If there's any news items, go build them
-          if ( !newsList.hasChildNodes() && state.loggedIn ) {
+          if ( !newsList.hasChildNodes()) {
             state.newsContent.forEach(async (newsItem) => {
               // Check for any catches to not display the item
               const hasLogicCheck = Object.prototype.hasOwnProperty.call(newsItem, "logicCheck");

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -10,6 +10,7 @@
     currentPanel: null,
     newsItemsCount: 0,
     loggedIn: false,
+    newsContent: []
   };
 
   // Block all API calls until user is signed-in
@@ -35,24 +36,22 @@
     const isBundleAvailable = isBundleAvailableInCountry && !hasVpn;
   
     // FIXME: The order is not being set correctly
-    const newsContent = [
-      {
-        id: "firefox-integration",
-        waffle: "firefox_integration",
-        locale: "us",
-        audience: "premium",
-        headlineString: "popupPasswordManagerRelayHeadline",
-        bodyString: "popupPasswordManagerRelayBody",
-        teaserImg:
-          "/images/panel-images/announcements/panel-announcement-password-manager-relay-square-illustration.svg",
-        fullImg:
-          "/images/panel-images/announcements/panel-announcement-password-manager-relay-illustration.svg",
-      },
-    ];
+    state.newsContent.push({
+      id: "firefox-integration",
+      waffle: "firefox_integration",
+      locale: "us",
+      audience: "premium",
+      headlineString: "popupPasswordManagerRelayHeadline",
+      bodyString: "popupPasswordManagerRelayBody",
+      teaserImg:
+        "/images/panel-images/announcements/panel-announcement-password-manager-relay-square-illustration.svg",
+      fullImg:
+        "/images/panel-images/announcements/panel-announcement-password-manager-relay-illustration.svg",
+    });
 
       // Add Phone Masking News Item
     if (isPhoneMaskingAvailable) {
-      newsContent.push({
+      state.newsContent.push({
         id: "phones",
         logicCheck: isPhoneMaskingAvailable,
         headlineString: "popupPhoneMaskingPromoHeadline",
@@ -81,7 +80,7 @@
         currency: getBundleCurrency,
       }).format(getBundlePrice);
       
-      newsContent.push({
+      state.newsContent.push({
         id: "mozilla-vpn-bundle",
         logicCheck: isBundleAvailable,
         headlineString: "popupBundlePromoHeadline_2",
@@ -102,7 +101,7 @@
     }
 
     // Update news item count
-    state.newsItemsCount = newsContent.length;
+    state.newsItemsCount = state.newsContent.length;
     
   }
   
@@ -725,9 +724,9 @@
 
           const newsList = document.querySelector(".fx-relay-news");
 
-          // If there's no news items, go build them
-          if ( !newsList.hasChildNodes() ) {
-            newsContent.forEach(async (newsItem) => {
+          // If there's any news items, go build them
+          if ( !newsList.hasChildNodes() && state.loggedIn ) {
+            state.newsContent.forEach(async (newsItem) => {
               // Check for any catches to not display the item
               const hasLogicCheck = Object.prototype.hasOwnProperty.call(newsItem, "logicCheck");
               
@@ -807,7 +806,14 @@
           },
           update: (newsItemId) => {
             // Get content for news detail view
-            const storyData = newsContent.filter((story) => { return story.id == newsItemId });
+
+            
+            if (!state.loggedIn) {
+              return;
+            }
+
+            const storyData = state.newsContent.filter((story) => { return story.id == newsItemId });
+            
             const newsItemContent = storyData[0];
             
             const newsStoryDetail = document.querySelector(".fx-relay-news-story");

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -1241,21 +1241,26 @@
         // Conditions for bundle announcement to be shown: if the user is in US/CAN, bundle flag is on, and user has not purchased bundle plan yet
         const isBundleAvailable = isBundleAvailableInCountry && !hasVpn;
       
+        // Conditions for firefox integration to be shown: if the waffle flag "firefox_integration" is set as true
+        const isFirefoxIntegrationAvailable = await checkWaffleFlag("firefox_integration");
+        
         // FIXME: The order is not being set correctly
-        state.newsContent.push({
-          id: "firefox-integration",
-          waffle: "firefox_integration",
-          locale: "us",
-          audience: "premium",
-          headlineString: "popupPasswordManagerRelayHeadline",
-          bodyString: "popupPasswordManagerRelayBody",
-          teaserImg:
-            "/images/panel-images/announcements/panel-announcement-password-manager-relay-square-illustration.svg",
-          fullImg:
-            "/images/panel-images/announcements/panel-announcement-password-manager-relay-illustration.svg",
-        });
+        if (isFirefoxIntegrationAvailable) {
+          state.newsContent.push({
+            id: "firefox-integration",
+            waffle: "firefox_integration",
+            locale: "us",
+            audience: "premium",
+            headlineString: "popupPasswordManagerRelayHeadline",
+            bodyString: "popupPasswordManagerRelayBody",
+            teaserImg:
+              "/images/panel-images/announcements/panel-announcement-password-manager-relay-square-illustration.svg",
+            fullImg:
+              "/images/panel-images/announcements/panel-announcement-password-manager-relay-illustration.svg",
+          });
+        }
 
-          // Add Phone Masking News Item
+        // Add Phone Masking News Item
         if (isPhoneMaskingAvailable) {
           state.newsContent.push({
             id: "phones",

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -8,100 +8,104 @@
 
   const state = {
     currentPanel: null,
-    newsItemsCount: 0
+    newsItemsCount: 0,
+    loggedIn: false,
   };
 
-  // audience can be premium, free, phones, all
-  // Optional data: waffle, fullCta*
-  const savings = "40%"; // For "Save 40%!" in the Bundle promo body
-  
-  const isBundleAvailableInCountry = (
-    await browser.storage.local.get("bundlePlans")
-  ).bundlePlans.BUNDLE_PLANS.available_in_country;
-  const isPhoneAvailableInCountry = (
-    await browser.storage.local.get("phonePlans")
-  ).phonePlans.PHONE_PLANS.available_in_country;
-
-  
-
-  const hasPhone = (await browser.storage.local.get("has_phone")).has_phone;
-  const hasVpn = (await browser.storage.local.get("has_vpn")).has_vpn;
-
-  // Conditions for phone masking announcement to be shown: if the user is in US/CAN, phone flag is on, and user has not purchased phone plan yet
-  const isPhoneMaskingAvailable = isPhoneAvailableInCountry && !hasPhone;
-
-  // Conditions for bundle announcement to be shown: if the user is in US/CAN, bundle flag is on, and user has not purchased bundle plan yet
-  const isBundleAvailable = isBundleAvailableInCountry && !hasVpn;
- 
-  // FIXME: The order is not being set correctly
-  const newsContent = [
-    {
-      id: "firefox-integration",
-      waffle: "firefox_integration",
-      locale: "us",
-      audience: "premium",
-      headlineString: "popupPasswordManagerRelayHeadline",
-      bodyString: "popupPasswordManagerRelayBody",
-      teaserImg:
-        "/images/panel-images/announcements/panel-announcement-password-manager-relay-square-illustration.svg",
-      fullImg:
-        "/images/panel-images/announcements/panel-announcement-password-manager-relay-illustration.svg",
-    },
-  ];
-
-  // Add Phone Masking News Item
-  if (isPhoneMaskingAvailable) {
-    newsContent.push({
-      id: "phones",
-      logicCheck: isPhoneMaskingAvailable,
-      headlineString: "popupPhoneMaskingPromoHeadline",
-      bodyString: "popupPhoneMaskingPromoBody",
-      teaserImg:
-        "/images/panel-images/announcements/premium-announcement-phone-masking.svg",
-      fullImg:
-        "/images/panel-images/announcements/premium-announcement-phone-masking-hero.svg",
-      fullCta: "popupPhoneMaskingPromoCTA",
-      fullCtaRelayURL: true,
-      fullCtaHref:
-        "premium/#pricing?utm_source=fx-relay-addon&utm_medium=popup&utm_content=panel-news-phone-masking-cta",
-      fullCtaEventLabel: "panel-news-phone-masking-cta",
-      fullCtaEventAction: "click",
-    });
-  }
-
-  // Add Bundle Pricing News Item
-  if (isBundleAvailable) {
-    const getBundlePlans = (await browser.storage.local.get("bundlePlans")).bundlePlans.BUNDLE_PLANS;
-    const getBundlePrice = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code].en.yearly.price;
-    const getBundleCurrency = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code].en.yearly.currency
-    const userLocale = navigator.language;
-    const formattedBundlePrice = new Intl.NumberFormat(userLocale, {
-      style: "currency",
-      currency: getBundleCurrency,
-    }).format(getBundlePrice);
+  // Block all API calls until user is signed-in
+  if (state.loggedIn) {
+    // audience can be premium, free, phones, all
+    // Optional data: waffle, fullCta*
+    const savings = "40%"; // For "Save 40%!" in the Bundle promo body
     
-    newsContent.push({
-      id: "mozilla-vpn-bundle",
-      logicCheck: isBundleAvailable,
-      headlineString: "popupBundlePromoHeadline_2",
-      headlineStringArgs: savings,
-      bodyString: "popupBundlePromoBody_3",
-      bodyStringArgs: formattedBundlePrice,
-      teaserImg:
-        "/images/panel-images/announcements/panel-bundle-announcement-square.svg",
-      fullImg:
-        "/images/panel-images/announcements/panel-bundle-announcement.svg",
-      fullCta: "popupPhoneMaskingPromoCTA",
-      fullCtaRelayURL: true,
-      fullCtaHref:
-        "/premium/#pricing?utm_source=fx-relay-addon&utm_medium=popup&utm_content=panel-news-bundle-cta",
-      fullCtaEventLabel: "panel-news-bundle-cta",
-      fullCtaEventAction: "click",
-    },)
-  }
+    const isBundleAvailableInCountry = (
+      await browser.storage.local.get("bundlePlans")
+    ).bundlePlans.BUNDLE_PLANS.available_in_country;
+    const isPhoneAvailableInCountry = (
+      await browser.storage.local.get("phonePlans")
+    ).phonePlans.PHONE_PLANS.available_in_country;
 
-  // Update news item count
-  state.newsItemsCount = newsContent.length;
+    const hasPhone = (await browser.storage.local.get("has_phone")).has_phone;
+    const hasVpn = (await browser.storage.local.get("has_vpn")).has_vpn;
+
+    // Conditions for phone masking announcement to be shown: if the user is in US/CAN, phone flag is on, and user has not purchased phone plan yet
+    const isPhoneMaskingAvailable = isPhoneAvailableInCountry && !hasPhone;
+
+    // Conditions for bundle announcement to be shown: if the user is in US/CAN, bundle flag is on, and user has not purchased bundle plan yet
+    const isBundleAvailable = isBundleAvailableInCountry && !hasVpn;
+  
+    // FIXME: The order is not being set correctly
+    const newsContent = [
+      {
+        id: "firefox-integration",
+        waffle: "firefox_integration",
+        locale: "us",
+        audience: "premium",
+        headlineString: "popupPasswordManagerRelayHeadline",
+        bodyString: "popupPasswordManagerRelayBody",
+        teaserImg:
+          "/images/panel-images/announcements/panel-announcement-password-manager-relay-square-illustration.svg",
+        fullImg:
+          "/images/panel-images/announcements/panel-announcement-password-manager-relay-illustration.svg",
+      },
+    ];
+
+      // Add Phone Masking News Item
+    if (isPhoneMaskingAvailable) {
+      newsContent.push({
+        id: "phones",
+        logicCheck: isPhoneMaskingAvailable,
+        headlineString: "popupPhoneMaskingPromoHeadline",
+        bodyString: "popupPhoneMaskingPromoBody",
+        teaserImg:
+          "/images/panel-images/announcements/premium-announcement-phone-masking.svg",
+        fullImg:
+          "/images/panel-images/announcements/premium-announcement-phone-masking-hero.svg",
+        fullCta: "popupPhoneMaskingPromoCTA",
+        fullCtaRelayURL: true,
+        fullCtaHref:
+          "premium/#pricing?utm_source=fx-relay-addon&utm_medium=popup&utm_content=panel-news-phone-masking-cta",
+        fullCtaEventLabel: "panel-news-phone-masking-cta",
+        fullCtaEventAction: "click",
+      });
+    }
+
+    // Add Bundle Pricing News Item
+    if (isBundleAvailable) {
+      const getBundlePlans = (await browser.storage.local.get("bundlePlans")).bundlePlans.BUNDLE_PLANS;
+      const getBundlePrice = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code].en.yearly.price;
+      const getBundleCurrency = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code].en.yearly.currency
+      const userLocale = navigator.language;
+      const formattedBundlePrice = new Intl.NumberFormat(userLocale, {
+        style: "currency",
+        currency: getBundleCurrency,
+      }).format(getBundlePrice);
+      
+      newsContent.push({
+        id: "mozilla-vpn-bundle",
+        logicCheck: isBundleAvailable,
+        headlineString: "popupBundlePromoHeadline_2",
+        headlineStringArgs: savings,
+        bodyString: "popupBundlePromoBody_3",
+        bodyStringArgs: formattedBundlePrice,
+        teaserImg:
+          "/images/panel-images/announcements/panel-bundle-announcement-square.svg",
+        fullImg:
+          "/images/panel-images/announcements/panel-bundle-announcement.svg",
+        fullCta: "popupPhoneMaskingPromoCTA",
+        fullCtaRelayURL: true,
+        fullCtaHref:
+          "/premium/#pricing?utm_source=fx-relay-addon&utm_medium=popup&utm_content=panel-news-bundle-cta",
+        fullCtaEventLabel: "panel-news-bundle-cta",
+        fullCtaEventAction: "click",
+      },)
+    }
+
+    // Update news item count
+    state.newsItemsCount = newsContent.length;
+    
+  }
+  
   
   const popup = {
     events: {
@@ -111,14 +115,18 @@
         const backNavLevel = e.target.dataset.navLevel;
 
         if (backNavLevel === "root") {
-          document
-            .querySelector(".js-internal-link.is-active")
-            ?.classList.remove("is-active");
+          document.querySelector(".js-internal-link.is-active")?.classList.remove("is-active");
         }
 
         // Custom rule to send "Closed Report Issue" event
         if (e.target.dataset.navId && e.target.dataset.navId === "webcompat") {
           sendRelayEvent("Panel", "click", "closed-report-issue");
+        }
+
+        // Catch back button clicks if the user is logged out
+        if (!state.loggedIn && backNavLevel === "root") {
+          popup.panel.update("sign-up");
+          return;
         }
 
         popup.panel.update(backTarget);
@@ -244,12 +252,15 @@
       const backButtons = document.querySelectorAll(
         ".fx-relay-panel-header-btn-back"
       );
+      
       backButtons.forEach((button) => {
         button.addEventListener("click", popup.events.backClick, false);
       });
 
+      state.loggedIn = await popup.utilities.isUserSignedIn();
+
       // Check if user is signed in to show default/sign-in panel
-      if (await popup.utilities.isUserSignedIn()) {
+      if (state.loggedIn) {
         popup.panel.update("masks");
         popup.utilities.unhideNavigationItemsOnceLoggedIn();
       } else {
@@ -263,8 +274,12 @@
       // Set Notification Bug for Unread News Items
       popup.panel.news.utilities.initNewsItemCountNotification();
 
-      // TODO: Focus On Generate Button for Free / Search Filter for Premiums
-
+      // Note: There's a chain of functions that run from init, and end with putting focus on the most reasonable element: 
+      // Cases:
+      //   If not logged in: focused on "Sign In" button
+      //   (Both tiers) If no masks made: focused on primary generate mask button
+      //   If free tier: focused on "Create mask" button
+      //   If premium tier: focused in search bar
     },
     panel: {
       update: (panelId, data) => {
@@ -302,21 +317,9 @@
             popup.panel.news.storyPanel.update(data.newsItemId);
             break;
           case "settings":
-            popup.utilities.enableInputIconDisabling();
-            // Function is imported from data-opt-out-toggle.js
-            enableDataOptOut();
-
-            document
-              .getElementById("popupSettingsReportIssue")
-              .addEventListener(
-                "click",
-                (e) => {
-                  e.preventDefault();
-                  popup.panel.update("webcompat");
-                },
-                false
-              );
-
+            sendRelayEvent("Panel", "click", "opened-settings");
+            popup.panel.settings.init();
+            
             break;
           case "stats":
             sendRelayEvent("Panel", "click", "opened-stats");
@@ -696,11 +699,14 @@
               // Show Upgrade Button
               const getUnlimitedMasksBtn = document.querySelector(".fx-relay-mask-upgrade-button");
               getUnlimitedMasksBtn.classList.remove("is-hidden");
+              getUnlimitedMasksBtn.focus();
+
             } else {
               
               // Show Masks Count/Generate Button
               masksAvailable.classList.remove("is-hidden");
               generateRandomMask.classList.remove("is-hidden");
+              generateRandomMask.focus();
             }
           
             
@@ -922,6 +928,26 @@
             }
           }
         },
+      },
+      settings: {
+        init: () => {
+          popup.utilities.enableInputIconDisabling();
+
+          // Function is imported from data-opt-out-toggle.js
+          enableDataOptOut();
+
+          const reportWebcompatIssueLink = document.getElementById("popupSettingsReportIssue");
+            
+          if (state.loggedIn) {
+            reportWebcompatIssueLink.classList.remove("is-disabled");
+            reportWebcompatIssueLink.addEventListener("click", (e) => {
+                e.preventDefault();
+                popup.panel.update("webcompat");
+              }, false);
+          } else {
+            reportWebcompatIssueLink.classList.add("is-disabled");
+          }
+        }
       },
       stats: {
         init: async () => {

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -859,13 +859,13 @@
           const reportWebcompatIssueLink = document.getElementById("popupSettingsReportIssue");
             
           if (state.loggedIn) {
-            reportWebcompatIssueLink.classList.remove("is-disabled");
+            reportWebcompatIssueLink.classList.remove("is-hidden");
             reportWebcompatIssueLink.addEventListener("click", (e) => {
                 e.preventDefault();
                 popup.panel.update("webcompat");
               }, false);
           } else {
-            reportWebcompatIssueLink.classList.add("is-disabled");
+            reportWebcompatIssueLink.classList.add("is-hidden");
           }
         }
       },

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -14,14 +14,6 @@
   // audience can be premium, free, phones, all
   // Optional data: waffle, fullCta*
   const savings = "40%"; // For "Save 40%!" in the Bundle promo body
-  const getBundlePlans = (await browser.storage.local.get("bundlePlans")).bundlePlans.BUNDLE_PLANS;
-  const getBundlePrice = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code].en.yearly.price;
-  const getBundleCurrency = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code].en.yearly.currency
-  const userLocale = navigator.language;
-  const formattedBundlePrice = new Intl.NumberFormat(userLocale, {
-    style: "currency",
-    currency: getBundleCurrency,
-  }).format(getBundlePrice);
   
   const isBundleAvailableInCountry = (
     await browser.storage.local.get("bundlePlans")
@@ -29,6 +21,8 @@
   const isPhoneAvailableInCountry = (
     await browser.storage.local.get("phonePlans")
   ).phonePlans.PHONE_PLANS.available_in_country;
+
+  
 
   const hasPhone = (await browser.storage.local.get("has_phone")).has_phone;
   const hasVpn = (await browser.storage.local.get("has_vpn")).has_vpn;
@@ -42,6 +36,22 @@
   // FIXME: The order is not being set correctly
   const newsContent = [
     {
+      id: "firefox-integration",
+      waffle: "firefox_integration",
+      locale: "us",
+      audience: "premium",
+      headlineString: "popupPasswordManagerRelayHeadline",
+      bodyString: "popupPasswordManagerRelayBody",
+      teaserImg:
+        "/images/panel-images/announcements/panel-announcement-password-manager-relay-square-illustration.svg",
+      fullImg:
+        "/images/panel-images/announcements/panel-announcement-password-manager-relay-illustration.svg",
+    },
+  ];
+
+  // Add Phone Masking News Item
+  if (isPhoneMaskingAvailable) {
+    newsContent.push({
       id: "phones",
       logicCheck: isPhoneMaskingAvailable,
       headlineString: "popupPhoneMaskingPromoHeadline",
@@ -56,9 +66,21 @@
         "premium/#pricing?utm_source=fx-relay-addon&utm_medium=popup&utm_content=panel-news-phone-masking-cta",
       fullCtaEventLabel: "panel-news-phone-masking-cta",
       fullCtaEventAction: "click",
-    },
+    });
+  }
 
-    {
+  // Add Bundle Pricing News Item
+  if (isBundleAvailable) {
+    const getBundlePlans = (await browser.storage.local.get("bundlePlans")).bundlePlans.BUNDLE_PLANS;
+    const getBundlePrice = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code].en.yearly.price;
+    const getBundleCurrency = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code].en.yearly.currency
+    const userLocale = navigator.language;
+    const formattedBundlePrice = new Intl.NumberFormat(userLocale, {
+      style: "currency",
+      currency: getBundleCurrency,
+    }).format(getBundlePrice);
+    
+    newsContent.push({
       id: "mozilla-vpn-bundle",
       logicCheck: isBundleAvailable,
       headlineString: "popupBundlePromoHeadline_2",
@@ -75,20 +97,8 @@
         "/premium/#pricing?utm_source=fx-relay-addon&utm_medium=popup&utm_content=panel-news-bundle-cta",
       fullCtaEventLabel: "panel-news-bundle-cta",
       fullCtaEventAction: "click",
-    },
-    {
-      id: "firefox-integration",
-      waffle: "firefox_integration",
-      locale: "us",
-      audience: "premium",
-      headlineString: "popupPasswordManagerRelayHeadline",
-      bodyString: "popupPasswordManagerRelayBody",
-      teaserImg:
-        "/images/panel-images/announcements/panel-announcement-password-manager-relay-square-illustration.svg",
-      fullImg:
-        "/images/panel-images/announcements/panel-announcement-password-manager-relay-illustration.svg",
-    },
-  ];
+    },)
+  }
 
   // Update news item count
   state.newsItemsCount = newsContent.length;


### PR DESCRIPTION
## Summary 

This PR addresses multiple QA issues found in initial testing from @AOiegas

Other fixes beyond what QA has filed: 
- Added logic to hide the navigation item for the News panel if there are no news items available to show (unread or otherwise) 
  - _When testing this, you can use a VPN on Stage to limit which is visible. Note that the Firefox Integration flag is set to true on Stage, so it will always return at least one news item_
- Added logic to set focus state correctly everytime you open the panel (regardless of logged in/out state or tier/mask count) 

Known caveats:
- The "new item" count is not working currently

Links:
- Jira Tickets:
  - https://mozilla-hub.atlassian.net/browse/MPP-2857 (Loading Error when Installing)
  - https://mozilla-hub.atlassian.net/browse/MPP-2848 (Settings while signed in error)
- Epic PR #456 


## Testing

**MPP-2857**

_Dev Note: Do not use `web-ext` for this test_

- Open up clean install/profile of Firefox
- Log into Relay
- Close Relay dashboard page
- Go to `about:debugging` or `about:addons` and install add-on 
- Open panel
- **Expected:** You should get the login panel

**MPP-2857**

- Install add-on
- Do NOT log in
- Open panel
- **Expected:** You should get the login panel
- Click on Settings navigation item
- **Expected:** You should get the settings panel AND the "Report Issue" link should be disabled/faded out/unclickable
- Click back button
**Expected:** You should get the login panel again

## Screenshots
N/A