### PR TITLE
Process GitHub Actions deprecations

### DIFF
--- a/.github/workflows/sign-and-release-to-github.yml
+++ b/.github/workflows/sign-and-release-to-github.yml
@@ -58,7 +58,10 @@ jobs:
         run: git submodule update --init --recursive --remote
 
       - name: "Set up node"
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v3.4.1
+        with:
+          node-version: 16
+          cache: 'npm'
 
       - name: "Install"
         run: npm install

--- a/.github/workflows/sign-and-release-to-github.yml
+++ b/.github/workflows/sign-and-release-to-github.yml
@@ -91,11 +91,11 @@ jobs:
             jq ".version = \"$VERSION\"" src/manifest.json > manifest.json~;
             mv manifest.json~ src/manifest.json;
             git diff;
-            echo ::set-output name=version::$(echo $VERSION);
+            echo "version=$VERSION" >> $GITHUB_OUTPUT;
           # But when pushing a tag, just pass on the manifest.json version to other steps:
           else
             export VERSION=$(jq ".version" src/manifest.json);
-            echo ::set-output name=version::${VERSION//\"/};
+            echo "version=${VERSION//\"/}" >> $GITHUB_OUTPUT;
           fi
         env:
           REF_TYPE: ${{ github.ref_type }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: "Make release notes"
         id: release_notes
-        run: echo ::set-output name=release_notes::$(git log --no-merges --pretty=format:"%h %s" ${{ steps.version.outputs.version }}^..${{ steps.version.outputs.version }})
+        run: echo 'release_notes=$(git log --no-merges --pretty=format:"%h %s" ${{ steps.version.outputs.version }}^..${{ steps.version.outputs.version }})' >> $GITHUB_OUTPUT;
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
I just noticed a bunch of deprecations in the prerelease job:

![image](https://user-images.githubusercontent.com/4251/224327537-74191c31-10ce-4385-b5ba-2306626b1064.png)

So I bumped the Node version to 16, and incorporated this change for output variables: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/