### PR TITLE
Fix MPP-2857 - Add logic to prompt user to login if any authentication information is missing

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -247,7 +247,8 @@ sign-up-panel::after {
   justify-content: center;
   align-items: center;
   text-align: center;
-  padding-top: var(--layoutSm);
+  /* Padding note: Bottom padding is necessary for bottom/fixed sign-in button */
+  padding: var(--layoutSm) 0 var(--layoutLg);
 }
 
 .fx-relay-sign-in-copy img {

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -173,6 +173,7 @@
   top: calc(100% + var(--spacingXs));
   right: 0;
   white-space: nowrap;
+  pointer-events: none;
 }
 
 .fx-relay-menu-dashboard-link:hover .fx-relay-menu-dashboard-link-tooltip,

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -1196,6 +1196,15 @@
           userApiToken,
           "apiToken"
         );
+
+        // MPP-2857: During upgrade, the profile ID may be dropped, so if that is not 
+        // available to the add-on, prompt the user to reauthenticate
+        const { profileID } = await browser.storage.local.get("profileID");
+
+        if (!profileID) {
+          return false;
+        }
+        
         return signedInUser;
       },
       getCachedServerStoragePref: async () => {


### PR DESCRIPTION
## Summary

This PR addresses a possible migration issue where the `profileID` variable (saved in local storage) is missing. This can result in a broken/loading state in the popup. The fix here is to check if that variable is accessible during the init function. If it's missing, we prompt the user to re-login in to add it back correctly. 

Fixes:
- [MPP-2857](https://mozilla-hub.atlassian.net/browse/MPP-2857)
- [MPP-2861](https://mozilla-hub.atlassian.net/browse/MPP-2861)
- [MPP-3013](https://mozilla-hub.atlassian.net/browse/MPP-3013)

## Steps to reproduce

- Run the add-on as normal, log in
  - Just in case, please close the dashboard page.
- Open `about:devtools-toolbox?id=private-relay%40firefox.com&type=extension` 
- Run the following console command to remove the `profileID` from local storage 
  - `await browser.storage.local.remove("profileID");`
- Open panel
- **Expected:** You should see the logged out "sign in" prompt
- Click "Sign in", and go through auth flow again
- Open panel again 
- **Expected:** You should see mask list, etc. (Normal experience) 


## Screenshots

N/A