### PR TITLE
Only suggest inserting masks in text fields

### DIFF
--- a/src/js/background/context-menu.js
+++ b/src/js/background/context-menu.js
@@ -8,21 +8,21 @@ const staticMenuData = {
   existingAlias: {
     type: "radio",
     visible: true,
-    contexts: ["all"],
+    contexts: ["editable"],
   },
   generateAliasEnabled: {
     id: "fx-private-relay-generate-alias",
     title: browser.i18n.getMessage("pageInputIconGenerateNewAlias_mask"),
     enabled: true,
     visible: true,
-    contexts: ["all"],
+    contexts: ["editable"],
   },
   generateAliasDisabled: {
     id: "fx-private-relay-generate-alias",
     title: browser.i18n.getMessage("pageInputIconGenerateNewAlias_mask"),
     enabled: false,
     visible: true,
-    contexts: ["all"],
+    contexts: ["editable"],
   },
   manageAliases: {
     id: "fx-private-relay-manage-aliases",
@@ -35,7 +35,7 @@ const staticMenuData = {
     title: browser.i18n.getMessage("pageInputIconInsertPhoneMask"),
     enabled: true,
     visible: true,
-    contexts: ["all"],
+    contexts: ["editable"],
   },
   upgradeToPremium: {
     id: "fx-private-relay-get-unlimited-aliases",
@@ -55,13 +55,13 @@ const staticMenuData = {
       "pageInputIconUseExistingAliasFromTheSite_mask"
     ),
     visible: true,
-    contexts: ["all"],
+    contexts: ["editable"],
   },
   useExistingAlias: {
     id: "fx-private-relay-use-existing-aliases",
     title: browser.i18n.getMessage("pageInputIconRecentAliases_mask"),
     visible: true,
-    contexts: ["all"],
+    contexts: ["editable"],
   },
 };
 


### PR DESCRIPTION
The context menu entries to generate/reuse a mask only really make sense if the user is right-clicking an editable field. (Ideally even just email address fields, but we don't have an API that allows us to detect that.) @maxxcrawford let me know if there was a reason you initially had these set to `all`. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/ContextType.

This PR fixes MPP-3014.

How to test: right-click an email input - nothing should have changed. Right-click anything else, e.g. the Relay icon in the toolbar, and you should not have options to generate or reuse a mask.

- [x] l10n changes have been submitted to the l10n repository, if any.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
