### PR TITLE
Fix MPP-3063 #495 - Use local storage to load inital masks

### DIFF
--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -1,4 +1,4 @@
-/* global getBrowser checkWaffleFlag psl */
+/* global getBrowser checkWaffleFlag getSHA256Hash psl */
 
 (async () => {
   // Global Data
@@ -1266,7 +1266,7 @@
               options,
             });
 
-            const hash = await popup.utilities.getSHA256Hash(JSON.stringify(masksFromServer));
+            const hash = await getSHA256Hash(JSON.stringify(masksFromServer));
             
             await browser.storage.local.set({
               hashOfRemoteServerMasks: hash,
@@ -1303,15 +1303,6 @@
         // User is not syncing with the server. Use local storage.
         const { relayAddresses } = await browser.storage.local.get("relayAddresses");
         return relayAddresses;
-      },
-      getSHA256Hash: async (input) => {
-        const textAsBuffer = new TextEncoder().encode(input);
-        const hashBuffer = await window.crypto.subtle.digest("SHA-256", textAsBuffer);
-        const hashArray = Array.from(new Uint8Array(hashBuffer));
-        const hash = hashArray
-          .map((item) => item.toString(16).padStart(2, "0"))
-          .join("");
-        return hash;
       },
       populateNewsFeed: async ()=> {
         // audience can be premium, free, phones, all

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -297,7 +297,7 @@
           const maskPanel = document.getElementById("masks-panel");
           const { relayAddresses } = await browser.storage.local.get("relayAddresses");
 
-          let getMasksOptions = { fetchCustomMasks: false, updateLocalMasks: false, source: "masks.init" };
+          let getMasksOptions = { fetchCustomMasks: false, updateLocalMasks: false };
           
           if (!premium) {
             await popup.panel.masks.utilities.setRemainingMaskCount();
@@ -452,7 +452,7 @@
         },
         utilities: {
           buildMasksList: async (localMasks = null, opts = null, remoteMasks = null) => {
-            let getMasksOptions = { fetchCustomMasks: false, updateLocalMasks: false, source: "utils.buildMasksList"  };
+            let getMasksOptions = { fetchCustomMasks: false, updateLocalMasks: false };
             const { premium } = await browser.storage.local.get("premium");
 
             if (premium) {
@@ -606,7 +606,7 @@
               return maskListItem;
           },
           getRemainingAliases: async () => {
-            const masks = await popup.utilities.getMasks({source: "getRemainingAliases"});
+            const masks = await popup.utilities.getMasks();
             const { maxNumAliases } = await browser.storage.local.get("maxNumAliases");
             return { masks, maxNumAliases };
           },
@@ -883,7 +883,7 @@
           // Check if user is premium (and then check if they have a domain set)
           // This is needed in order to query both random and custom masks
           const { premium } = await browser.storage.local.get("premium");
-          let getMasksOptions = { fetchCustomMasks: false, source: "stats.init" };
+          let getMasksOptions = { fetchCustomMasks: false };
 
           if (premium) {
             // Check if user may have custom domain masks
@@ -1261,7 +1261,7 @@
         });
         return currentTab;
       },
-      getMasks: async (options = { fetchCustomMasks: false, updateLocalMasks: false, source: "test" }) => {
+      getMasks: async (options = { fetchCustomMasks: false, updateLocalMasks: false }) => {
         const serverStoragePref =
           await popup.utilities.getCachedServerStoragePref();
 

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -488,11 +488,48 @@
             const { hashOfRemoteServerMasks } = await browser.storage.local.get("hashOfRemoteServerMasks");
 
             const maskList = document.querySelector(".fx-relay-mask-list");
+            
             // Reset mask list
             maskList.textContent = "";
 
+            // Make row element for each mask and append it to mask list
             masks.forEach(mask => {
-              const maskListItem = document.createElement("li");
+              const maskListItem = popup.panel.masks.utilities.buildMaskListItem(mask);
+              maskList.appendChild(maskListItem);
+            });
+
+            // Display "Mask created" temporary label when a new mask is created in the panel
+            if (opts && opts.newMaskCreated && maskList.firstElementChild) {
+              maskList.firstElementChild.classList.add("is-new-mask");
+
+              setTimeout(() => {
+                maskList.firstElementChild.classList.remove("is-new-mask");
+              }, 1000);
+            }
+
+            console.log(hashOfLocalStorageMasks, hashOfRemoteServerMasks);
+            
+            if ( hashOfLocalStorageMasks !== hashOfRemoteServerMasks) {
+              // TODO: Write update function that takes masks as argument
+              console.log("Update mask list for masks from server")
+              // console.log(masksFromApi);
+            }
+
+            // If user has no masks created, focus on random gen button
+            if (masks.length === 0) {
+              const generateRandomMask = document.querySelector(".js-generate-random-mask");
+              generateRandomMask.focus();
+              return;
+            }
+
+            // If premium, focus on search instead
+            if (premium) {
+              popup.panel.masks.search.init();
+            }
+
+          },
+          buildMaskListItem: (mask) => {
+            const maskListItem = document.createElement("li");
 
               // Attributes used to power search filtering
               maskListItem.setAttribute("data-mask-address", mask.full_address);              
@@ -566,38 +603,7 @@
 
               maskListItemAddressBar.appendChild(maskListItemAddressActions);
               maskListItem.appendChild(maskListItemAddressBar);
-              maskList.appendChild(maskListItem);
-            });
-
-            // Display "Mask created" temporary label when a new mask is created in the panel
-            if (opts && opts.newMaskCreated && maskList.firstElementChild) {
-              maskList.firstElementChild.classList.add("is-new-mask");
-
-              setTimeout(() => {
-                maskList.firstElementChild.classList.remove("is-new-mask");
-              }, 1000);
-            }
-
-            console.log(hashOfLocalStorageMasks, hashOfRemoteServerMasks);
-            
-            if ( hashOfLocalStorageMasks !== hashOfRemoteServerMasks) {
-              // TODO: Write update function that takes masks as argument
-              console.log("Update mask list for masks from server")
-              // console.log(masksFromApi);
-            }
-
-            // If user has no masks created, focus on random gen button
-            if (masks.length === 0) {
-              const generateRandomMask = document.querySelector(".js-generate-random-mask");
-              generateRandomMask.focus();
-              return;
-            }
-
-            // If premium, focus on search instead
-            if (premium) {
-              popup.panel.masks.search.init();
-            }
-
+              return maskListItem;
           },
           getRemainingAliases: async () => {
             const masks = await popup.utilities.getMasks({source: "getRemainingAliases"});

--- a/src/js/shared/utils.js
+++ b/src/js/shared/utils.js
@@ -1,4 +1,4 @@
-/* exported areInputIconsEnabled setCustomFonts preventDefaultBehavior checkWaffleFlag getBrowser */
+/* exported areInputIconsEnabled setCustomFonts preventDefaultBehavior checkWaffleFlag getBrowser getSHA256Hash */
 
 // eslint-disable-next-line no-redeclare
 async function areInputIconsEnabled() {
@@ -65,4 +65,15 @@ async function getBrowser() {
     return "Firefox";
   }
   return "Chrome";
+}
+
+// eslint-disable-next-line no-unused-vars
+async function getSHA256Hash(input) { 
+  const textAsBuffer = new TextEncoder().encode(input);
+  const hashBuffer = await window.crypto.subtle.digest("SHA-256", textAsBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hash = hashArray
+    .map((item) => item.toString(16).padStart(2, "0"))
+    .join("");
+  return hash;
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -56,7 +56,7 @@
       "matches": [
           "http://127.0.0.1/accounts/profile/**"
       ],
-      "js": ["js/libs/browser-polyfill.min.js", "js/relay.firefox.com/get_profile_data.js"]
+      "js": ["js/libs/browser-polyfill.min.js", "js/shared/utils.js", "js/relay.firefox.com/get_profile_data.js"]
     },
     {
       "matches": [


### PR DESCRIPTION
## Summary 
This PR reduces the load time when a user is logged in and opens the panels to view their masks. 

This fixes: 
- [MPP-3063](https://mozilla-hub.atlassian.net/browse/MPP-3063)
- #495 

TODO
- [ ] Remove extra API call to get latest masks
  - [ ] Confirm other pages do not make the same call. Use local storage to power other panels (Stats)
- [ ] Build initial masks lists on local (stale) date 
- [ ] Update masks accordingly when API call finishes loading (add new masks, update status of other masks) 

## Testing

TBD

## Screenshots

TBD