### PR TITLE
[MPP-3063] Reduce panel load time

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -921,7 +921,7 @@ sign-up-panel::after {
 .fx-relay-menu-loading-bar {
   width: 100%;
   height: 5px;
-  position: relative;
+  position: absolute;
   overflow: hidden;
   display: none;
 }

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -476,85 +476,14 @@
             const masks = await popup.utilities.getMasks(getMasksOptions);
             
             const maskList = document.querySelector(".fx-relay-mask-list");
+
             // Reset mask list
             maskList.textContent = "";
-
-            masks.forEach(mask => {
-              const maskListItem = document.createElement("li");
-
-              // Attributes used to power search filtering
-              maskListItem.setAttribute("data-mask-address", mask.full_address);              
-              maskListItem.setAttribute("data-mask-description", mask.description ?? "");
-              maskListItem.setAttribute("data-mask-used-on", mask.used_on ?? "");
-              maskListItem.setAttribute("data-mask-generated", mask.generated_for ?? "");
-              
-              maskListItem.classList.add("fx-relay-mask-item");
-
-              const maskListItemNewMaskCreatedLabel = document.createElement("span");
-              maskListItemNewMaskCreatedLabel.textContent = browser.i18n.getMessage("labelMaskCreated");
-              maskListItemNewMaskCreatedLabel.classList.add("fx-relay-mask-item-new-mask-created");
-              maskListItem.appendChild(maskListItemNewMaskCreatedLabel);
-              
-              const maskListItemAddressBar = document.createElement("div");
-              maskListItemAddressBar.classList.add("fx-relay-mask-item-address-bar");
-
-              const maskListItemAddressWrapper = document.createElement("div");
-              maskListItemAddressWrapper.classList.add("fx-relay-mask-item-address-wrapper");
-
-              const maskListItemLabel = document.createElement("span");
-              maskListItemLabel.classList.add("fx-relay-mask-item-label");
-              maskListItemLabel.textContent = mask.description;
-              
-              // Append Label if it exists
-              if (mask.description !== "") {
-                maskListItemAddressWrapper.appendChild(maskListItemLabel);
-              }
-              
-              const maskListItemAddress = document.createElement("div");
-              maskListItemAddress.classList.add("fx-relay-mask-item-address");
-              maskListItemAddress.textContent = mask.full_address;
-              maskListItemAddressWrapper.appendChild(maskListItemAddress);
-
-              // Add Mask Address Bar Contents 
-              maskListItemAddressBar.appendChild(maskListItemAddressWrapper);
-
-              const maskListItemAddressActions = document.createElement("div");
-              maskListItemAddressActions.classList.add("fx-relay-mask-item-address-actions");
-
-              const maskListItemCopyButton = document.createElement("button");
-              maskListItemCopyButton.classList.add("fx-relay-mask-item-address-copy");
-              maskListItemCopyButton.setAttribute("data-mask-address", mask.full_address);
-
-              const maskListItemCopyButtonSuccessMessage = document.createElement("span");
-              maskListItemCopyButtonSuccessMessage.textContent = browser.i18n.getMessage("popupCopyMaskButtonCopied");
-              maskListItemCopyButtonSuccessMessage.classList.add("fx-relay-mask-item-address-copy-success");
-              maskListItemAddressActions.appendChild(maskListItemCopyButtonSuccessMessage);
-              
-              maskListItemCopyButton.addEventListener("click", (e)=> {
-                e.preventDefault();
-                navigator.clipboard.writeText(e.target.dataset.maskAddress);
-                maskListItemCopyButtonSuccessMessage.classList.add("is-shown");
-                setTimeout(() => {
-                  maskListItemCopyButtonSuccessMessage.classList.remove("is-shown")
-                }, 1000);
-              }, false);
-              maskListItemAddressActions.appendChild(maskListItemCopyButton);
-
-              const maskListItemToggleButton = document.createElement("button");
-              maskListItemToggleButton.classList.add("fx-relay-mask-item-address-toggle");
-              maskListItemToggleButton.addEventListener("click", ()=> {
-                // TODO: Add Toggle Function
-              }, false);
-              maskListItemToggleButton.setAttribute("data-mask-id", mask.id);
-              maskListItemToggleButton.setAttribute("data-mask-type", mask.mask_type);
-              maskListItemToggleButton.setAttribute("data-mask-address", mask.full_address);
-
-              // TODO: Add toggle button back
-              // maskListItemAddressActions.appendChild(maskListItemToggleButton);
-
-              maskListItemAddressBar.appendChild(maskListItemAddressActions);
-              maskListItem.appendChild(maskListItemAddressBar);
-              maskList.appendChild(maskListItem);
+            
+            // Generate and append each mask item to the mask list
+            masks.forEach( mask => {
+                const maskListItem = popup.panel.masks.utilities.buildMaskListItem(mask);
+                maskList.append(maskListItem);
             });
 
             // Display "Mask created" temporary label when a new mask is created in the panel
@@ -581,6 +510,83 @@
             // Remove loading state
             document.body.classList.remove("is-loading");
 
+          },
+          buildMaskListItem: (mask) => {
+            const maskListItem = document.createElement("li");
+
+            // Attributes used to power search filtering
+            maskListItem.setAttribute("data-mask-address", mask.full_address);              
+            maskListItem.setAttribute("data-mask-description", mask.description ?? "");
+            maskListItem.setAttribute("data-mask-used-on", mask.used_on ?? "");
+            maskListItem.setAttribute("data-mask-generated", mask.generated_for ?? "");
+            
+            maskListItem.classList.add("fx-relay-mask-item");
+
+            const maskListItemNewMaskCreatedLabel = document.createElement("span");
+            maskListItemNewMaskCreatedLabel.textContent = browser.i18n.getMessage("labelMaskCreated");
+            maskListItemNewMaskCreatedLabel.classList.add("fx-relay-mask-item-new-mask-created");
+            maskListItem.append(maskListItemNewMaskCreatedLabel);
+            
+            const maskListItemAddressBar = document.createElement("div");
+            maskListItemAddressBar.classList.add("fx-relay-mask-item-address-bar");
+
+            const maskListItemAddressWrapper = document.createElement("div");
+            maskListItemAddressWrapper.classList.add("fx-relay-mask-item-address-wrapper");
+
+            const maskListItemLabel = document.createElement("span");
+            maskListItemLabel.classList.add("fx-relay-mask-item-label");
+            maskListItemLabel.textContent = mask.description;
+            
+            // Append Label if it exists
+            if (mask.description !== "") {
+              maskListItemAddressWrapper.append(maskListItemLabel);
+            }
+            
+            const maskListItemAddress = document.createElement("div");
+            maskListItemAddress.classList.add("fx-relay-mask-item-address");
+            maskListItemAddress.textContent = mask.full_address;
+            maskListItemAddressWrapper.append(maskListItemAddress);
+
+            // Add Mask Address Bar Contents 
+            maskListItemAddressBar.append(maskListItemAddressWrapper);
+
+            const maskListItemAddressActions = document.createElement("div");
+            maskListItemAddressActions.classList.add("fx-relay-mask-item-address-actions");
+
+            const maskListItemCopyButton = document.createElement("button");
+            maskListItemCopyButton.classList.add("fx-relay-mask-item-address-copy");
+            maskListItemCopyButton.setAttribute("data-mask-address", mask.full_address);
+
+            const maskListItemCopyButtonSuccessMessage = document.createElement("span");
+            maskListItemCopyButtonSuccessMessage.textContent = browser.i18n.getMessage("popupCopyMaskButtonCopied");
+            maskListItemCopyButtonSuccessMessage.classList.add("fx-relay-mask-item-address-copy-success");
+            maskListItemAddressActions.append(maskListItemCopyButtonSuccessMessage);
+            
+            maskListItemCopyButton.addEventListener("click", (e)=> {
+              e.preventDefault();
+              navigator.clipboard.writeText(e.target.dataset.maskAddress);
+              maskListItemCopyButtonSuccessMessage.classList.add("is-shown");
+              setTimeout(() => {
+                maskListItemCopyButtonSuccessMessage.classList.remove("is-shown")
+              }, 1000);
+            }, false);
+            maskListItemAddressActions.append(maskListItemCopyButton);
+
+            const maskListItemToggleButton = document.createElement("button");
+            maskListItemToggleButton.classList.add("fx-relay-mask-item-address-toggle");
+            maskListItemToggleButton.addEventListener("click", ()=> {
+              // TODO: Add Toggle Function
+            }, false);
+            maskListItemToggleButton.setAttribute("data-mask-id", mask.id);
+            maskListItemToggleButton.setAttribute("data-mask-type", mask.mask_type);
+            maskListItemToggleButton.setAttribute("data-mask-address", mask.full_address);
+
+            // TODO: Add toggle button back
+            // maskListItemAddressActions.append(maskListItemToggleButton);
+
+            maskListItemAddressBar.append(maskListItemAddressActions);
+            maskListItem.append(maskListItemAddressBar);
+            return maskListItem;
           },
           getRemainingAliases: async () => {
             const masks = await popup.utilities.getMasks();

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -342,24 +342,10 @@
               popup.events.generateMask(e, "random");
             }, false);
           
-          // Get masks and determine what to display
-          const { relayAddresses } = await browser.storage.local.get(
-            "relayAddresses"
-          );
-
-          // If no masks are created, show onboarding prompt
-          if (relayAddresses.length === 0) {
-            const noMasksCreatedPanel = document.querySelector(".fx-relay-no-masks-created");
-            noMasksCreatedPanel.classList.remove("is-hidden");
-          }
-
           // Build initial list
           // Note: If premium, buildMasksList runs `popup.panel.masks.search.init()` after completing
+          // If no masks are created, this will show onboarding prompt
           popup.panel.masks.utilities.buildMasksList();
-        
-
-          
-
         },
         search: {
           filter: (query)=> {
@@ -495,10 +481,16 @@
               }, 1000);
             }
 
-            // If user has no masks created, focus on random gen button
+            // If user has no masks created, show onboarding prompt and focus on random gen button
             if (masks.length === 0) {
+              const noMasksCreatedPanel = document.querySelector(".fx-relay-no-masks-created");
+              noMasksCreatedPanel.classList.remove("is-hidden");
+              
               const generateRandomMask = document.querySelector(".js-generate-random-mask");
               generateRandomMask.focus();
+
+              // Remove loading state since exiting early
+              document.body.classList.remove("is-loading");
               return;
             }
 

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -1251,15 +1251,10 @@
 
         if (serverStoragePref) {
           try {
-            const masks = await browser.runtime.sendMessage({
+            return await browser.runtime.sendMessage({
               method: "getAliasesFromServer",
               options,
             });
-
-            await browser.storage.local.set({"relayAddresses": masks});
-
-            return masks;
-
           } catch (error) {
             console.warn(`getAliasesFromServer Error: ${error}`);
 

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -873,15 +873,16 @@
             getMasksOptions.fetchCustomMasks = isPremiumSubdomainSet;
           }
 
-          const masks = await popup.utilities.getMasks(getMasksOptions);
+          // Use localStorage of Masks
+          const { relayAddresses } = await browser.storage.local.get("relayAddresses");
 
            // Get Global Mask Stats data
-          const totalAliasesUsedVal = masks.length;
+          const totalAliasesUsedVal = relayAddresses.length;
           let totalEmailsForwardedVal = 0;
           let totalEmailsBlockedVal = 0;
           
           // Loop through all masks to calculate totals
-          masks.forEach((mask) => {
+          relayAddresses.forEach((mask) => {
             totalEmailsForwardedVal += mask.num_forwarded;
             totalEmailsBlockedVal += mask.num_blocked;
           });
@@ -902,10 +903,10 @@
           });
 
           // Check if any data applies to the current site
-          if ( popup.utilities.checkIfAnyMasksWereGeneratedOnCurrentWebsite(masks,currentPageHostName) ) {
+          if ( popup.utilities.checkIfAnyMasksWereGeneratedOnCurrentWebsite(relayAddresses,currentPageHostName) ) {
             
             // Some masks are used on the current site. Time to calculate!
-            const filteredMasks = masks.filter(
+            const filteredMasks = relayAddresses.filter(
               (mask) =>
                 mask.generated_for === currentPageHostName ||
                 popup.utilities.hasMaskBeenUsedOnCurrentSite(

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -343,10 +343,12 @@
             }, false);
           
           // Get masks and determine what to display
-          const masks = await popup.utilities.getMasks(getMasksOptions);
+          const { relayAddresses } = await browser.storage.local.get(
+            "relayAddresses"
+          );
 
           // If no masks are created, show onboarding prompt
-          if (masks.length === 0) {
+          if (relayAddresses.length === 0) {
             const noMasksCreatedPanel = document.querySelector(".fx-relay-no-masks-created");
             noMasksCreatedPanel.classList.remove("is-hidden");
           }
@@ -356,8 +358,7 @@
           popup.panel.masks.utilities.buildMasksList();
         
 
-          // Remove loading state
-          document.body.classList.remove("is-loading");
+          
 
         },
         search: {
@@ -576,6 +577,9 @@
             if (premium) {
               popup.panel.masks.search.init();
             }
+
+            // Remove loading state
+            document.body.classList.remove("is-loading");
 
           },
           getRemainingAliases: async () => {
@@ -1240,10 +1244,15 @@
 
         if (serverStoragePref) {
           try {
-            return await browser.runtime.sendMessage({
+            const masks = await browser.runtime.sendMessage({
               method: "getAliasesFromServer",
               options,
             });
+
+            await browser.storage.local.set({"relayAddresses": masks});
+
+            return masks;
+
           } catch (error) {
             console.warn(`getAliasesFromServer Error: ${error}`);
 

--- a/src/js/relay.firefox.com/get_profile_data.js
+++ b/src/js/relay.firefox.com/get_profile_data.js
@@ -257,29 +257,27 @@
     if (siteStorageEnabled) {
       // Sync alias data from server page.
       // If local storage items exist AND have label metadata stored, sync it to the server.
-      const serverRelayAddresses = await apiRequest(relayApiUrlRelayAddresses);
-      const serverDomainAddresses = isPremiumUser
-        ? await apiRequest(relayApiUrlDomainAddresses)
-        : [];
+      const remoteCopyOfServerMasks = await browser.runtime.sendMessage({
+        method: "getAliasesFromServer",
+        options: { fetchCustomMasks: isPremiumUser },
+      });
 
       // let usage: This data may be overwritten when merging the local storage dataset with the server set.
-      let localCopyOfServerMasks = serverRelayAddresses.concat(serverDomainAddresses);
+      let localCopyOfServerMasks = remoteCopyOfServerMasks;
 
       // Check/cache local storage
-      const localMasks = (await browser.storage.local.get(
-        "relayAddresses"
-      )).relayAddresses;
+      const { relayAddresses } = await browser.storage.local.get("relayAddresses");
 
       if (
-        localMasks &&
-        localMasks.length > 0 &&
-        aliasesHaveStoredMetadata(localMasks) && // Make sure there is meta data in the local dataset
+        relayAddresses &&
+        relayAddresses.length > 0 &&
+        aliasesHaveStoredMetadata(relayAddresses) && // Make sure there is meta data in the local dataset
         !aliasesHaveStoredMetadata(localCopyOfServerMasks) // Make sure there is no meta data in the server dataset
       ) {
-        await sendMetaDataToServer(localMasks);
+        await sendMetaDataToServer(relayAddresses);
         localCopyOfServerMasks = getAliasesWithUpdatedMetadata(
           localCopyOfServerMasks,
-          localMasks
+          relayAddresses
         );
       }
 
@@ -297,14 +295,14 @@
       "firefox-private-relay-addon"
     ).addEventListener("website", async (event) => {
       if (event.detail.type === "labelUpdate") {
-        const existingAddresses = (await browser.storage.local.get("relayAddresses")).relayAddresses;
+        const { relayAddresses } = await browser.storage.local.get("relayAddresses");
         const update = event.detail;
-        const oldAddress = existingAddresses.find(existingAddress =>
+        const oldAddress = relayAddresses.find(existingAddress =>
           existingAddress.id === update.alias.id &&
           existingAddress.address === update.alias.address &&
           existingAddress.domain === update.alias.domain
         );
-        const newAddresses = existingAddresses.filter(existingAddress => existingAddress !== oldAddress);
+        const newAddresses = relayAddresses.filter(existingAddress => existingAddress !== oldAddress);
         newAddresses.push({
           ...oldAddress,
           description: update.newLabel,


### PR DESCRIPTION
## Summary 
This PR reduces the load time when a user is logged in and opens the panels to view their masks. 

This fixes: 
- [MPP-3063](https://mozilla-hub.atlassian.net/browse/MPP-3063)
- #495 

TODO
- [x] Remove extra API call to get latest masks
  - [x] Confirm other pages do not make the same call. Use local storage to power other panels (Stats)
- [x] ~Build initial masks lists on local (stale) date~ Disregarding for now
  - [x] ~Update masks accordingly when API call finishes loading (add new masks, update status of other masks)~ 
- [x] Move "save to local storage" logic when API is called for masks to background scripts
- [x] Edge case: Update mask view accordingly when API call finishes loading if on empty (no mask) state

## Testing

For context, compare these actions to the production release with the same account. 

- If possible, use personal Relay account with 100+ accounts (May have to run `$ npm run config:prod`) 
- Log into account
- Open panel
- **Expected:** Panel should load within ~1s and the loading state should be visible until the data is shown
- Open stats
- **Expected:** Panel should load INSTANTLY with data 

## Screenshots

TBD