### PR TITLE
[Add-on Refactor] Visual Clean-up

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -2,6 +2,7 @@
 
 .fx-relay {
   /* Spacing/Layout Tokens */
+  --spacing2xs: 2px;
   --spacingXs: 4px;
   --spacingSm: 8px;
   --spacingMd: 16px;

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -117,6 +117,7 @@
   outline: 0;
   border: none;
   background-color: transparent;
+  cursor: pointer;
 }
 
 .fx-relay-menu-dashboard-link .news-count {

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -825,9 +825,12 @@ sign-up-panel::after {
 .fx-relay-mask-item-label {
   font-size: var(--fontSizeBodyXs);
   color: var(--colorGrey40);
+  text-overflow: ellipsis;
   overflow: hidden;
   display: block;
   line-height: 1;
+  /* Custom height to account for cropped descender text */
+  height: 13px;
 }
 
 .fx-relay-mask-item-address-bar {
@@ -838,7 +841,7 @@ sign-up-panel::after {
 
 .fx-relay-mask-item-address-wrapper {
   display: flex;
-  gap: var(--spacingXs);
+  gap: var(--spacing2xs);
   flex-direction: column;
   width: calc( 100% - var(--spacingMd));
   position: relative;

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -190,6 +190,7 @@
   justify-content: center;
   align-items: center;
   width: 100%;
+  padding: 0 var(--spacingXl);
 }
 
 .fx-relay-panel-header-btn-back {
@@ -220,6 +221,10 @@
   font-size: var(--fontSizeTitle3xs);
   font-family: var(--fontStackFirefox);
   font-weight: 500;
+  text-align: center;
+  line-height: 1.2;
+  width: 100%;
+  
 }
 
 /* Sign Up/In Panel */

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -4,6 +4,7 @@
   --panelWidth: 360px;
   /* Any changes to --panelHeight should be reflected in the screen media query */
   --panelHeight: 400px;
+  --panelHeaderHeight: 49px;
   background-color: var(--colorGrey05);
   min-width: var(--panelWidth);
   max-width: var(--panelWidth);
@@ -77,6 +78,8 @@
   top: 0;
   /* Z-index usage: This needs to be over absolute elements inside the main content area of the panel (MPP-3006) */
   z-index: 2;
+  /* Custom height defined to fix visual bug on Firefox for loading animation */
+  height: var(--panelHeaderHeight);
 }
 
 .fx-relay-menu-header-logo-bar {
@@ -939,7 +942,8 @@ sign-up-panel::after {
   position: absolute;
   overflow: hidden;
   display: none;
-  top: 49px;
+  /* Magic number: This is the height of the "header" for the pop-up. */
+  top: var(--panelHeaderHeight);
 }
 
 .fx-relay-menu-loading-bar-wrapper {

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -55,6 +55,12 @@
   margin-bottom: 100px;
 }
 
+/* Custom fix for Firefox bug where changing panel size from large to small does not trigger refresh */
+#masks-panel[data-account-level="premium"].custom-return .fx-relay-panel-content {
+  min-height: 300px;
+  max-height: 300px;
+}
+
 #webcompat-panel .fx-relay-panel-content {
   padding-top: var(--spacingSm);
 }

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -933,6 +933,7 @@ sign-up-panel::after {
   position: absolute;
   overflow: hidden;
   display: none;
+  top: 49px;
 }
 
 .fx-relay-menu-loading-bar-wrapper {

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -29,6 +29,19 @@
           sendRelayEvent("Panel", "click", "closed-report-issue");
         }
 
+        // Custom rule to fix Firefox bug where popup does not 
+        // resize from larger sized panels to smaller sized panels
+        if (e.target.dataset.navId && e.target.dataset.navId === "custom") {
+          console.log("custom back to masks");
+          const maskPanel = document.querySelector("masks-panel");
+          maskPanel.classList.add("custom-return");
+          
+          setTimeout(() => {
+            maskPanel.classList.remove("custom-return");
+          }, 10);
+          
+        }
+
         // Catch back button clicks if the user is logged out
         if (!sessionState.loggedIn && backNavLevel === "root") {
           popup.panel.update("sign-up");

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -180,6 +180,9 @@
       // Set External Event Listerners
       await popup.utilities.setExternalLinkEventListeners();
 
+      // Clear browser action "!" badge
+      await popup.utilities.clearBrowserActionBadge();
+
       // Note: There's a chain of functions that run from init, and end with putting focus on the most reasonable element: 
       // Cases:
       //   If not logged in: focused on "Sign In" button
@@ -1127,9 +1130,7 @@
         });
       },
       clearBrowserActionBadge: async () => {
-        const { browserActionBadgesClicked } = await browser.storage.local.get(
-          "browserActionBadgesClicked"
-        );
+        const { browserActionBadgesClicked } = await browser.storage.local.get("browserActionBadgesClicked");
 
         // Dismiss the browserActionBadge only when it exists
         if (browserActionBadgesClicked === false) {
@@ -1365,6 +1366,7 @@
         sessionState.newsItemsCount = sessionState.newsContent.length;
 
         // Set unread notification count
+        // TODO: Move some of this logic to get_profile_data to set the browserActionBadge to a #
         await popup.panel.news.utilities.initNewsItemCountNotification();
       },
       setExternalLinkEventListeners: async () => {

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -32,7 +32,6 @@
         // Custom rule to fix Firefox bug where popup does not 
         // resize from larger sized panels to smaller sized panels
         if (e.target.dataset.navId && e.target.dataset.navId === "custom") {
-          console.log("custom back to masks");
           const maskPanel = document.querySelector("masks-panel");
           maskPanel.classList.add("custom-return");
           

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -61,6 +61,7 @@
         e.target.classList.add("is-active");
         const panelId = e.target.dataset.panelId;
         popup.panel.update(panelId);
+        e.target.blur();
       },
       generateMask: async (event, type = "random", data = null) => {
         

--- a/src/popup.html
+++ b/src/popup.html
@@ -145,7 +145,7 @@
         <custom-panel data-panel-id="custom" class="is-hidden fx-relay-panel" id="custom-panel">
           <header class="fx-relay-panel-header">
             <!-- Back Button -->
-            <button data-nav-id="custom" data-nav-level="child" data-back-target="masks" class="fx-relay-panel-header-btn-back">
+            <button data-nav-id="custom" data-nav-level="root" data-back-target="masks" class="fx-relay-panel-header-btn-back">
               <img class="i18n-alt-tag" data-i18n-message-id="returnToPreviousPanel" src="/icons/nebula-back-arrow.svg" alt="">
             </button>
             


### PR DESCRIPTION
## Summary

After launching the new add-on, there are some minor visual issues. This PR addresses them!

This PR fixes: 
- #491
- #493
- #492
- #494
- #501 

## Testing

See screenshots for all that don't need tests

#492 (And loading bar issue not reported) 

- Load add-on with premium account (subdomain registered) in Firefox browser
- Open panel
- **Expected:** The loading bar should be visible
- Click "Generate custom mask"
- Click back button
- **Expected** The "Generate random mask" should NOT be clipped



## Screenshots

#491

<img width="396" alt="image" src="https://user-images.githubusercontent.com/2692333/233700088-a361fb40-ce0e-4d61-b415-8df1eaae0b01.png">

#493

![Apr-21-2023 13-06-29](https://user-images.githubusercontent.com/2692333/233705156-0ced4a16-c31f-4207-b79f-ccec13159c9b.gif)

#494 

<img width="392" alt="image" src="https://user-images.githubusercontent.com/2692333/233706446-852d6687-a907-4441-ac36-af8251e47b61.png">

#501

![Apr-21-2023 14-02-01](https://user-images.githubusercontent.com/2692333/233714677-e038e20c-93d4-4694-b271-a699fc80a52b.gif)
