### PR TITLE
MPP-3368 

### DIFF
--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -1390,8 +1390,8 @@
         // Add Bundle Pricing News Item
         if (isBundleAvailable) {
           const getBundlePlans = (await browser.storage.local.get("bundlePlans")).bundlePlans.BUNDLE_PLANS;
-          const getBundlePrice = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code].en.yearly.price;
-          const getBundleCurrency = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code].en.yearly.currency
+          const getBundlePrice = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code]["*"].yearly.price;
+          const getBundleCurrency = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code]["*"].yearly.currency;
           const userLocale = navigator.language;
           const formattedBundlePrice = new Intl.NumberFormat(userLocale, {
             style: "currency",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3368 

# New feature description
Update how we access bundle plan yearly price and currency for news item in popup.js to select `*` (used to be `en` for

`const getBundlePrice = getBundlePlans.plan_country_lang_mapping[getBundlePlans.country_code].en.yearly.price;`

# Screenshot (if applicable)

<img width="338" alt="image" src="https://github.com/mozilla/fx-private-relay-add-on/assets/3924990/12dba53f-3ad1-4e7e-812c-5ec2679d3d3d">


# How to test

You should be able to see the news items. 

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
