### PR TITLE
MPP-3416: Input labels can get blocked by email values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fx-private-relay-add-on",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fx-private-relay-add-on",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MPL-2.0",
       "devDependencies": {
         "eslint": "^8.13.0",

--- a/src/js/other-websites/fill_relay_address.js
+++ b/src/js/other-websites/fill_relay_address.js
@@ -15,9 +15,11 @@ function fillInputWithAlias(emailInput, relayAlias) {
   // Set the value of the target field to the selected/generated mask
   emailInput.value = emailMask;
 
-
   emailInput.dispatchEvent(new Event('input', {bubbles:true}));
-
+  // 'change' event, is needed to trigger the change event listeners (i.e this event is needed when 
+  // clicking a mask from the relay button, instead of typing it, since change events run when the input is out of focus (input events don't))
+  // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
+  emailInput.dispatchEvent(new Event('change', {bubbles:true}));
 }
 
 function fillInputWithRelayNumber(emailInput, relayNumber) {

--- a/src/js/other-websites/fill_relay_address.js
+++ b/src/js/other-websites/fill_relay_address.js
@@ -37,9 +37,8 @@ function fillInputWithRelayNumber(emailInput, relayNumber) {
     : relayNumber.number;
   emailInput.value = normalisedNumber;
 
-
   emailInput.dispatchEvent(new Event('input', {bubbles:true}));
-
+  emailInput.dispatchEvent(new Event('change', {bubbles:true}));
 }
 
 

--- a/src/js/other-websites/icon.js
+++ b/src/js/other-websites/icon.js
@@ -106,7 +106,8 @@ function wireUpInputs(emailInputs) {
       event.preventDefault();
       openMenu(input);
     });
-    input.insertAdjacentElement("afterend", invisibleFocusableButton);
+
+    input.parentElement.appendChild(invisibleFocusableButton);
   }
 
   sendRelayEvent("In-page", "input-icon-injected", "input-icon");

--- a/src/js/other-websites/icon.js
+++ b/src/js/other-websites/icon.js
@@ -215,6 +215,7 @@ function openMenu(target) {
       // `address` does contain the full address (i.e. including @mozmail.com):
       target.value = message.newRelayAddressResponse.full_address ?? message.newRelayAddressResponse.address;
       target.dispatchEvent(new Event("input", { bubbles: true }));
+      target.dispatchEvent(new Event('change', { bubbles: true }));
       closeMenu();
     }
   };


### PR DESCRIPTION
This PR fixes [MPP-3416](https://mozilla-hub.atlassian.net/browse/MPP-3416).

# Bug description
An issue occurs in the login page of sso.mozilla.com where the relay email gets stacked ontop of the label/placeholder for the <input> tag. 

The issue occured because the CSS being used to move the label away during focus/typing was using the selectors `.form__input input:focus + label, .form__input input.has-contents + label`. This CSS uses `+ label`, which will only work when the `<label>` is the next adjacent element to the input. We were inserting an invisible button right after the input, which caused the CSS for the label to not render. To fix this issue, I added the button to the child of the input's parent element instead. 

Another issue that occurred was the `<input>` class name not getting updated when the user selects a relay address from the context and in-page menu's. The selector `.form__input input.has-contents + label`, which shows the label's css whenever the input's class is "hasContent", was not triggerred because the class remained "" unless the user manually types something. 

input class name does not get updated when selecting from these menus           |  input class name does not get updated when selecting from these menus 
:-------------------------:|:-------------------------:
![image](https://github.com/mozilla/fx-private-relay-add-on/assets/59676643/15630447-6276-4880-9396-e523e2177280) |  ![image](https://github.com/mozilla/fx-private-relay-add-on/assets/59676643/7d144ca3-2aeb-4c3f-b3f0-3298e024044b)

To solve this issue, I added the line `.dispatchEvent(new Event('change', {bubbles:true}));` when the data is being sent from either the context menu, or the in-page menu to trigger any change events.

# Demo of fix (if applicable)

https://github.com/mozilla/fx-private-relay-add-on/assets/59676643/8edc64db-c50f-480e-96c5-973f886bd1fa

# How to test
1. Go to sso.mozilla.com (if you are already signed in, sign out and click login)
2. [Acceptance criteria] Observe that typing an email does not stack ontop of the input label.
3. Refresh the page
4. Click on the email input
5. Right click to open the context menu and select a relay address from the Firefox Relay option
6. [Acceptance criteria] Observe that the mask that was put into the input field does not stack on the label.
7. Refresh the page
8. Click on the relay icon next to the input to open the in page menu
9. Click either 'generate new mask' or one of your existing masks
10. [Acceptance criteria] Observe that the mask that was put into the input field does not stack on the label

# Checklist

- [ ] All acceptance criteria are met.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
