### PR TITLE
(WIP) Prototype of Custom Setting that offsets Relay icon on email inputs to make room for other add-ons (Password Managers, etc).

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,8 @@ module.exports = {
         "relayContextMenus": "readonly",
         "sendMetricsEvent": "readonly",
         "sendRelayEvent": "readonly",
-        "setCustomFonts": "readonly"
+        "setCustomFonts": "readonly",
+        "isPwdMgrCompatEnabled": "readonly"
     },
     "rules": {
         "no-unused-vars": [

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -369,6 +369,7 @@ sign-up-panel::after {
 }
 
 .data-disabled::after,
+.pwdmgr-compat-disabled::after,
 .input-icons-disabled::after {
   left: 4px;
   right: 18px;
@@ -376,18 +377,22 @@ sign-up-panel::after {
 }
 
 .data-disabled:hover,
+.pwdmgr-compat-disabled:hover,
 .data-disabled:focus,
+.pwdmgr-compat-disabled:focus,
 .input-icons-disabled:hover,
 .input-icons-disabled:focus {
   background-color: var(--colorGrey40);
 }
 
 .data-disabled:active,
+.pwdmgr-compat-disabled:active,
 .input-icons-disabled:active {
   background-color: var(--colorGrey50);
 }
 
 .data-disabled,
+.pwdmgr-compat-disabled,
 .input-icons-disabled {
   background-color: var(--colorGrey30);
 }

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -536,6 +536,9 @@ browser.runtime.onMessage.addListener(async (m, sender, _sendResponse) => {
     case "updateInputIconPref":
       browser.storage.local.set({ showInputIcons: m.iconPref });
       break;
+    case "updatePwdMgrCompatPref":
+      browser.storage.local.set({ pwdMgrCompat: m.pref });
+      break;
   }
   return response;
 });

--- a/src/js/other-websites/icon.js
+++ b/src/js/other-websites/icon.js
@@ -19,8 +19,15 @@ async function run() {
   if (!inputIconsAreEnabled) {
     return;
   }
+
+  const pwdMgrCompat = await isPwdMgrCompatEnabled();
+
+  if (pwdMgrCompat) {
+    // TODO: Set RELAY_ICON_WIDTH width, hover state calcs
+  }
+
   const emailInputs = findEmailInputs(document);
-  wireUpInputs(emailInputs);
+  wireUpInputs(emailInputs, pwdMgrCompat);
 
   const potentialNewInputObserver = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
@@ -30,7 +37,7 @@ async function run() {
       for (const addedNode of mutation.addedNodes) {
         if (addedNode instanceof HTMLElement) {
           const addedEmailInputs = findEmailInputs(addedNode);
-          wireUpInputs(addedEmailInputs);
+          wireUpInputs(addedEmailInputs, pwdMgrCompat);
         }
       }
     });
@@ -46,7 +53,7 @@ async function run() {
  * @param {HTMLInputElement[]} emailInputs 
  * @returns void
  */
-function wireUpInputs(emailInputs) {
+function wireUpInputs(emailInputs, pwdMgrCompat) {
   if (emailInputs.length === 0) {
     return;
   }
@@ -60,6 +67,8 @@ function wireUpInputs(emailInputs) {
       backgroundImage: computedStyles.backgroundImage,
       backgroundRepeat: computedStyles.backgroundRepeat,
       backgroundPosition: computedStyles.backgroundPosition,
+      backgroundPositionX: computedStyles.backgroundPositionX,
+      backgroundPositionY: computedStyles.backgroundPositionY,
       backgroundOrigin: computedStyles.backgroundOrigin,
     };
     const iconUrl = (
@@ -70,9 +79,14 @@ function wireUpInputs(emailInputs) {
       existingStyles.backgroundImage + `, url("${iconUrl}")`;
     input.style.backgroundRepeat =
       existingStyles.backgroundRepeat + ", no-repeat";
-    input.style.backgroundPosition =
-      existingStyles.backgroundPosition +
-      `, right calc(50% - ((${computedStyles.paddingTop} - ${computedStyles.paddingBottom}) / 2))`;
+    input.style.backgroundPositionY =
+      existingStyles.backgroundPositionY +
+      `, calc(50% - ((${computedStyles.paddingTop} - ${computedStyles.paddingBottom}) / 2))`;
+    // Note - We're calculating X/Y differently to offset the icon when another icon is visible
+    input.style.backgroundPositionX = pwdMgrCompat ?
+      existingStyles.backgroundPositionX +
+      `, calc(100% - 32px)` : existingStyles.backgroundPositionX +
+      `, right`;
     input.style.backgroundOrigin =
       existingStyles.backgroundOrigin + ", content-box";
     input.removeEventListener("click", onEmailInputClick);

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -897,6 +897,7 @@
       settings: {
         init: () => {
           popup.utilities.enableInputIconDisabling();
+          popup.utilities.togglePwdMgrCompat();
 
           // Function is imported from data-opt-out-toggle.js
           enableDataOptOut();
@@ -1774,6 +1775,36 @@
 
           link.addEventListener("click", popup.events.externalClick, false);
         });
+      },
+      togglePwdMgrCompat: async () => {
+        const pwdMgrCompatPrefToggle = document.querySelector(".toggle-pwdmgr-compat");
+        
+        const stylePrefToggle = (userPref) => {
+          if (userPref === "pwdmgr-compat-enabled") {
+            pwdMgrCompatPrefToggle.classList.remove("pwdmgr-compat-disabled");
+            pwdMgrCompatPrefToggle.dataset.pwdMgrCompatPreference = "pwdmgr-compat-disabled";
+            return;
+          }
+          pwdMgrCompatPrefToggle.classList.add("pwdmgr-compat-disabled");
+          pwdMgrCompatPrefToggle.dataset.pwdMgrCompatPreference = "pwdmgr-compat-enabled";
+        };
+
+
+        const { pwdMgrCompat } = await browser.storage.local.get("pwdMgrCompat");
+
+        if (!pwdMgrCompat) {
+          browser.storage.local.set({ "pwdMgrCompat": "pwdmgr-compat-enabled" });
+          stylePrefToggle("pwdmgr-compat-enabled")
+        } else {
+          stylePrefToggle(pwdMgrCompat);
+        }
+
+        pwdMgrCompatPrefToggle.addEventListener("click", async(e) => {
+          const pwdMgrCompatPreference = e.target.dataset.pwdMgrCompatPreference;
+          await browser.storage.local.set({ "pwdMgrCompat" : pwdMgrCompatPreference });
+          stylePrefToggle(pwdMgrCompatPreference);
+        });
+        
       },
       unhideNavigationItemsOnceLoggedIn: () => {
         document

--- a/src/js/shared/utils.js
+++ b/src/js/shared/utils.js
@@ -1,4 +1,4 @@
-/* exported areInputIconsEnabled setCustomFonts preventDefaultBehavior checkWaffleFlag getBrowser */
+/* exported areInputIconsEnabled isPwdMgrCompatEnabled setCustomFonts preventDefaultBehavior checkWaffleFlag getBrowser */
 
 // eslint-disable-next-line no-redeclare
 async function areInputIconsEnabled() {
@@ -8,6 +8,16 @@ async function areInputIconsEnabled() {
     return true;
   }
   return (showInputIcons === "show-input-icons");
+}
+
+// eslint-disable-next-line no-redeclare
+async function isPwdMgrCompatEnabled() {
+  const { pwdMgrCompat } = await browser.storage.local.get("pwdMgrCompat");
+  if (!pwdMgrCompat) {
+    browser.storage.local.set({ "showInputIcons" : "pwdmgr-compat-enabled"})
+    return true;
+  }
+  return (pwdMgrCompat === "pwdmgr-compat-enabled");
 }
 
 // This function is defined as global in the ESLint config _because_ it is created here:

--- a/src/popup.html
+++ b/src/popup.html
@@ -215,6 +215,13 @@
                 <span class="fx-relay-settings-toggle-label i18n-content" data-i18n-message-id="popupSettingsCollectData"></span>
                 <button title="" data-icon-visibility-option="disable-input-icon" class="data-collection fx-relay-settings-toggle"></button>
               </div>
+              <div class="fx-relay-settings-toggle-wrapper">
+                <!-- TODO: Localize string -->
+                <span class="fx-relay-settings-toggle-label xi18n-content" data-i18n-message-id="popupSettingsCollectData">
+                  Password manager compatibility mode 
+                </span>
+                <button title="" data-icon-visibility-option="disable-input-icon" class="toggle-pwdmgr-compat fx-relay-settings-toggle"></button>
+              </div>
             </div> 
             <div class="fx-relay-settings-links">
               <!-- Leave Feedback -->


### PR DESCRIPTION
This is not feature complete and would require lots of QA across a few "supported" add-ons.

In addition to this PR, there's another angle to come from: The "management" permission (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/management)

This permission should be optional, but would allow us to detect if any other email-input add-ons were installed and update our positions accordingly. I recommend making it optional/opt-in. It's a pretty pervasive permission.
