### PR TITLE
MPP-1851 - Change how we get the locale for CSAT banner

### DIFF
--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -1239,7 +1239,7 @@
           },
           shouldShowSurvey: async () => {
             const reasonToShow = await popup.panel.survey.utils.getReasonToShowSurvey();
-            const locale = navigator.language;
+            const locale = browser.i18n.getUILanguage()
 
             return (
               reasonToShow !== null &&


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3433 - issue found while QA looked at MPP-1851 with user locale. 

https://mozilla-hub.atlassian.net/browse/MPP-3433
 
# New feature description

This changes how we check for user locale. It shows correctly now based on language set on browser. 

# Screenshot (if applicable)

<img width="662" alt="image" src="https://github.com/mozilla/fx-private-relay-add-on/assets/3924990/ca9243f2-02af-498a-bcc2-6f559b9f2d53">

# How to test

Change language to `es` and banner will not show. Change language to `en` `fr` or `de` and banner will show. 

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
