### PR TITLE
Add waffle flag for CSAT survey

### DIFF
--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -322,8 +322,9 @@
 
           // logic to show survey is found in shouldShowSurvey function
           const shouldShowCSAT = await popup.panel.survey.utils.shouldShowSurvey();
-
-          if (shouldShowCSAT && dataCollection === "data-enabled") {
+          const csatSurveyFlag = await checkWaffleFlag('csat_survey');
+          
+          if (shouldShowCSAT && csatSurveyFlag && dataCollection === "data-enabled") {
             const survey = popup.panel.survey;
 
             survey.utils.showSurveyLink();


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->
   
# New feature description

This adds a flag that controls if the CSAT survey shows in the add-on. Flag is `csat_survey` 

# Screenshot (if applicable)

 
<img width="352" alt="image" src="https://github.com/mozilla/fx-private-relay-add-on/assets/3924990/a69b3419-9703-4b71-b8c6-425d49370aff">


# How to test

Original PR: https://github.com/mozilla/fx-private-relay-add-on/pull/490 for main feature.

This is now behind `csat_survey` flag. 

Follow testing instructions in above PR link and make sure to turn on the `csat_survey` - survey should not show up if the flag is turned off. 

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
