### PR TITLE
MPP-3243 Rebrand Firefox Account in Firefox Relay

### DIFF
--- a/src/first-run.html
+++ b/src/first-run.html
@@ -21,7 +21,7 @@
       <div class="first-run-content">
         <h1 class="first-run-h1 show-700">Firefox Relay</h1>
         <div class="first-run-copy-wrapper">
-          <p class="first-run-p i18n-content" data-i18n-message-id="firstRunP"></p>
+          <p class="first-run-p i18n-content" data-i18n-message-id="firstRunP2"></p>
           <div class="collection-options">
             <span class="setting-label flex-col i18n-content" data-i18n-message-id="firstRunCollectDataLabel"></span>
             <button title="" class="data-collection fx-relay-toggle"></button>

--- a/src/js/other-websites/icon.js
+++ b/src/js/other-websites/icon.js
@@ -7,7 +7,7 @@ const COLOR_VIOLET_20 = "#f68fff";
 const COLOR_VIOLET_30 = "#f770ff";
 
 async function run() {
-  // Don't run on Firefox accounts; creating a Relay mask there can result in
+  // Don't run on Mozilla accounts; creating a Relay mask there can result in
   // an endless loop of self-referencing accounts:
   if ([
     "https://accounts.stage.mozaws.net",

--- a/src/popup.html
+++ b/src/popup.html
@@ -70,7 +70,7 @@
               <div class="fx-relay-sign-in-copy">
                 <img src="/images/panel-images/man-sitting-email.svg" alt="">
                 <h4 class="i18n-content" data-i18n-message-id="popupSignUpPanelWelcome"></h4>
-                <p class="i18n-content" data-i18n-message-id="popupSignUpPanelIntro"></p>
+                <p class="i18n-content" data-i18n-message-id="popupSignUpPanelIntro2"></p>
               </div>
               
               <!-- Log In Button -->


### PR DESCRIPTION
L10N: https://github.com/mozilla-l10n/fx-private-relay-add-on-l10n/pull/51

<!-- When fixing a bug: -->

This PR fixes [MPP-3243](https://mozilla-hub.atlassian.net/browse/MPP-3243)
 

# New feature description

As an account customer on Firefox Relay, seeing consistent branding of accounts across Mozilla surfaces helps me trust the authentication experience, and not feel confused about the services I use.

Rewrite Firefox Account(s) to account(s)

Comments, documentation updated - not behind a flag. 

# Screenshot (if applicable)

Not applicable.

# How to test

You can check the sign up panel and the first-run page for the updates. 

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
