### PR TITLE
Updated default_area attribute in manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
   "description": "__MSG_extensionDescription_mask__",
 
   "default_locale": "en",
-
+  "default_area": "navbar",
   "icons": {
     "16": "icons/icon_16.png",
     "48": "icons/icon_48.png",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->
<!-- When adding a new feature: -->

# New feature description

To ensure the mac icon is shown in the toolbar after installation, the default_area attribute has been updated to `navbar`

# Screenshot (if applicable)

Not applicable.

# How to test



# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
