### PR TITLE
Update add-on to non-persistent pages

### DIFF
--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -1,8 +1,13 @@
-const RELAY_SITE_ORIGIN = "http://127.0.0.1:8000";
+function startupInit() {
+  const RELAY_SITE_ORIGIN = "http://127.0.0.1:8000";  
+  browser.storage.local.set({ RELAY_SITE_ORIGIN });
+  browser.storage.local.set({ maxNumAliases: 5 });
+  browser.storage.local.set({ relaySiteOrigin: RELAY_SITE_ORIGIN });
+  browser.storage.local.set({ relayApiSource: `${RELAY_SITE_ORIGIN}/api/v1` });
+}
 
-browser.storage.local.set({ maxNumAliases: 5 });
-browser.storage.local.set({ relaySiteOrigin: RELAY_SITE_ORIGIN });
-browser.storage.local.set({ relayApiSource: `${RELAY_SITE_ORIGIN}/api/v1` });
+browser.runtime.onStartup.addListener(startupInit);
+
 
 browser.runtime.onInstalled.addListener(async (details) => {
   const { firstRunShown } = await browser.storage.local.get("firstRunShown");
@@ -249,6 +254,7 @@ async function sendMetricsEvent(eventData) {
 
   const ga_uuid = await getOrMakeGAUUID();
   const eventDataWithGAUUID = Object.assign({ ga_uuid }, eventData);
+  const { RELAY_SITE_ORIGIN } = await browser.storage.local.get("RELAY_SITE_ORIGIN");
   const sendMetricsEventUrl = `${RELAY_SITE_ORIGIN}/metrics-event`;
   fetch(sendMetricsEventUrl, {
     method: "POST",
@@ -294,6 +300,8 @@ async function refreshAccountPages() {
 async function makeDomainAddress(address, block_list_emails, description = null) {
   const apiToken = await browser.storage.local.get("apiToken");
 
+  const { RELAY_SITE_ORIGIN } = await browser.storage.local.get("RELAY_SITE_ORIGIN");
+  
   if (!apiToken.apiToken) {
     browser.tabs.create({
       url: RELAY_SITE_ORIGIN,
@@ -360,8 +368,10 @@ async function makeDomainAddress(address, block_list_emails, description = null)
 // eslint-disable-next-line no-redeclare
 async function makeRelayAddress(description = null) {
   const apiToken = await browser.storage.local.get("apiToken");
-
+  
   if (!apiToken.apiToken) {
+    const { RELAY_SITE_ORIGIN } = await browser.storage.local.get("RELAY_SITE_ORIGIN");
+    
     browser.tabs.create({
       url: RELAY_SITE_ORIGIN,
     });
@@ -481,6 +491,8 @@ async function displayBrowserActionBadge() {
 browser.runtime.onMessage.addListener(async (m, sender, _sendResponse) => {
   let response;
 
+  const { RELAY_SITE_ORIGIN } = await browser.storage.local.get("RELAY_SITE_ORIGIN");
+
   switch (m.method) {
     case "displayBrowserActionBadge":
       await displayBrowserActionBadge();
@@ -540,8 +552,8 @@ browser.runtime.onMessage.addListener(async (m, sender, _sendResponse) => {
   return response;
 });
 
-
 (async () => {
+  startupInit();
   await displayBrowserActionBadge();
   await storeRuntimeData();
 })();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,7 +26,8 @@
         "js/shared/utils.js",
         "js/background/background.js",
         "js/background/context-menu.js"
-      ]
+      ],
+      "persistent": false
   },
 
   "browser_action": {


### PR DESCRIPTION
This requires adding the `"persistent": false` to the manifest.json and removing and global variables from the background script. Luckily, we only had one: RELAY_SITE_ORIGIN. This commit moves it to local storage (and is set on start-up) and adjusted any other time its referenced to rely on localStorage for it.
