### PR TITLE
MPP-3396: Remove redundant scrollbar

### DIFF
--- a/src/css/in-page.css
+++ b/src/css/in-page.css
@@ -12,6 +12,7 @@
   font-family: var(--fontStackBase);
   font-size: 16px;
   -moz-osx-font-smoothing: grayscale;
+  overflow-y: hidden;
 }
 
 .fx-relay-menu-body.is-premium.is-loading {


### PR DESCRIPTION
This PR fixes [MPP-3396](https://mozilla-hub.atlassian.net/browse/MPP-3396).

# New feature description

There is a redundant scrollbar that shows up sometimes, but it is not needed. (See the ticket for examples)

# Screenshot of fix

Showcasing that there is no more redundant scrollbar in the body of the extension.

https://github.com/mozilla/fx-private-relay-add-on/assets/59676643/2585c18f-6ba9-4b24-953e-8468deff1fed

# How to test

1. Navigate to a website’s register page with an email field (e.g. Reddit sign up);

2. Open the Relay Field Icon menu;

3. Scroll inside it and observe that there is no scrollbar for the body of the extension

4. Optionally, generate a few masks and redo steps 1-3;


# Checklist
- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
