### PR TITLE
MPP-3395: Fix for menu size not reverting to its original state upon searching

### DIFF
--- a/src/css/in-page.css
+++ b/src/css/in-page.css
@@ -371,7 +371,7 @@
 }
 
 .fx-relay-menu-masks-search .fx-relay-menu-masks-list ul {
-  max-height: 190px;
+  height: 190px;
   overflow-y: scroll;
   scrollbar-width: thin;
   list-style: none;


### PR DESCRIPTION
This PR fixes [MPP-3395](https://mozilla-hub.atlassian.net/browse/MPP-3395).

<!-- When adding a new feature: -->

# Bug description
1. 
When searching in the relay add on menu, the sizing can change causing white space (only happens in the "All email masks" tab).
![image](https://github.com/mozilla/fx-private-relay-add-on/assets/59676643/c5c56021-4730-4168-ae6c-6a7cc9cb00f2)

2. 
When searching in the relay add on menu with a premium account and switching to the"All email masks" tab, then removing your search input, the size will not get reverted back to its original state (this only happens in the "All email masks" tab, and you have to click "All email masks" again for it to revert, as seen at the end of the bug demo).

You would need to use the scrollbar to move down and see the "Generate mask" button. (In https://github.com/mozilla/fx-private-relay-add-on/pull/531, this scrollbar is removed. The scrollbar is not needed with this PR's fix though, so there is no conflict here).

See the video here of the bug here:

https://github.com/mozilla/fx-private-relay-add-on/assets/59676643/8f39e98f-d911-484e-b737-e7debd04408a

# Demo of fix

https://github.com/mozilla/fx-private-relay-add-on/assets/59676643/0dd3a379-343a-41d3-93d6-ca32b0dae792

# How to test

1. Access a website that has a login form (e.g Reddit, Facebook, Youtube);

2. Create several masks, Field Icon should now display 2 tabs;

3. Search for a specific mask inside the Field Icon;

4. Cycle between tabs;

5. Observe behavior when removing the search input. The sizing should stay fixed.

# Checklist

- [x] All acceptance criteria are met.
- [x] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
