### PR TITLE
MPP-3551 Recurring every 90 days - show CSAT survey

### DIFF
--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -1213,20 +1213,15 @@
               const daysSinceFirstSeen =
                 (Date.now() - firstSeen.getTime()) / 1000 / 60 / 60 / 24;
 
-                console.log("daysSinceFirstSeen: ", daysSinceFirstSeen);
-
               if (daysSinceFirstSeen >= 90) {
                 isDismissed = await free90DaysDismissal.isDismissed();
-                console.log("isDismissed: ", isDismissed);
-
                 if (!isDismissed) {
-                  console.log("reasonToShow: free90days");
                   reasonToShow = "free90days";
                 }
               } else if (daysSinceFirstSeen >= 30) {
                 isDismissed = await free30DaysDismissal.isDismissed();
                 if (!isDismissed) {
-                  reasonToShow = "free30days"; 
+                  reasonToShow = "free30days";
                 }
               } else if (daysSinceFirstSeen >= 7) {
                 isDismissed = await free7DaysDismissal.isDismissed();
@@ -1824,7 +1819,7 @@
           const currentTime = Date.now();
           let dismissedTime = {
             value: currentTime,
-            duration: storageId.includes("90day") ? 90 * 24 * 60 * 60 * 1000 : undefined
+            duration: storageId.includes("90day") ? 90 * 24 * 60 * 60 * 1000 : undefined // this provides us the recurring 90 day dismissal
           };
         
           await browser.storage.local.set({ [storageId]: dismissedTime });

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -1804,17 +1804,17 @@
         const storageId = key + "_dismissed";
 
         const isDismissed = async () => {
-          let storedData = await browser.storage.local.get(storageId);
-          if (storedData[storageId]) {
+          let dismissedTime = await browser.storage.local.get(storageId);
+          if (dismissedTime[storageId]) {
             const currentTime = Date.now();
-            const elapsedTime = currentTime - storedData[storageId].value;
-            const maxAge = storedData[storageId].duration || (100 * 365 * 24 * 60 * 60 * 1000); // Default to 100 years if duration is not set
+            const elapsedTime = currentTime - dismissedTime[storageId].value;
+            const maxAge = dismissedTime[storageId].duration || (100 * 365 * 24 * 60 * 60 * 1000); // Default to 100 years if duration is not set
         
             return elapsedTime < maxAge;
           }
           return false;
         };
-        
+
         const dismiss = async (dismissOptions = {}) => {
           const currentTime = Date.now();
           let dismissedTime = {


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes MPP-3551
 
# New feature description

After the first month, then show the banner every 3 months

# Screenshot (if applicable)

Not applicable.

# How to test

You should be able to see the CSAT survey banner if you modify the appropriate key in your extension storage.

![image](https://github.com/mozilla/fx-private-relay-add-on/assets/3924990/c8805457-988c-404f-ac1d-b7d7ad29fb61)

Depending on your profileID, yours will look different. I set the value to 1693440000000 which is the equivalent of August 31st, 2023.  

You can test the dismissal of the banner, closing banner (with x) should not permanently remove it, but dismissing it intentionally should make it go away until the next cycle (90 days and every 90 days thereafter). To make it show up again, change your local time to 90 days in the future. You can dismiss it again and it shouldn't show up. Then change your date to 90 days in the future and it should work. 

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
