### PR TITLE
Add UTM params for GA use

### DIFF
--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -1748,7 +1748,7 @@
         if (isHolidayPromo2023Available && !premium && isHolidayPromo2023Active && premiumAvailability) {
           const getPeriodicalPremiumPlanYearlyId = getPeriodicalPremiumPlans.plan_country_lang_mapping[getPeriodicalPremiumPlans.country_code]["*"].yearly.id;
           const fxaOrigin = (await browser.storage.local.get("fxaOrigin")).fxaOrigin.FXA_ORIGIN;
-          const holidayPromo2023Url =  `${fxaOrigin}/subscriptions/products/${getPeriodicalPremiumProductId}?plan=${getPeriodicalPremiumPlanYearlyId}&coupon=HOLIDAY20`;
+          const holidayPromo2023Url =  `${fxaOrigin}/subscriptions/products/${getPeriodicalPremiumProductId}?plan=${getPeriodicalPremiumPlanYearlyId}&coupon=HOLIDAY20&utm_source=fx-relay-addon&utm_medium=popup&utm_content=panel-news-holiday-promo-2023-cta`;
 
           sessionState.newsContent.push({
             id: "holiday-promo-2023",


### PR DESCRIPTION
<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This addresses the Holiday Coupon telemetry. 

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description

Add UTM parameters for the holiday coupon work.

We added `&utm_source=fx-relay-addon&utm_medium=popup&utm_content=panel-news-holiday-promo-2023-cta`

# Screenshot (if applicable)

Not applicable.

# How to test

View links in new news item for holiday promo.

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
