### PR TITLE
Ensure context menus are created properly

### DIFF
--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -501,6 +501,7 @@ async function displayBrowserActionBadge() {
   }
 }
 
+// NOTE: (#545) When using `browser.runtime.sendMessage` as an async function - you must return a response or the message will timeout/fail
 browser.runtime.onMessage.addListener((m, sender, sendResponse) => {
   (async () => {
     let response = null;

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -554,7 +554,7 @@ browser.runtime.onMessage.addListener((m, sender, sendResponse) => {
         await refreshAccountPages();
         break;
       case "sendMetricsEvent":
-        response = await sendMetricsEvent(m.eventData);
+        sendMetricsEvent(m.eventData);
         break;
       case "updateAddOnAuthStatus":
         await updateAddOnAuthStatus(m.status);

--- a/src/js/other-websites/inpage_menu.js
+++ b/src/js/other-websites/inpage_menu.js
@@ -3,7 +3,7 @@ let masks = {};
 
 async function iframeCloseRelayInPageMenu() {
   document.removeEventListener("keydown", handleKeydownEvents);
-  await browser.runtime.sendMessage({ method: "iframeCloseRelayInPageMenu" });
+  browser.runtime.sendMessage({ method: "iframeCloseRelayInPageMenu" });
 }
 
 function getRelayMenuEl() {
@@ -30,7 +30,7 @@ async function handleKeydownEvents(e) {
 
   if (e.key === "Escape") {
     preventDefaultBehavior(e);
-    await iframeCloseRelayInPageMenu();
+    iframeCloseRelayInPageMenu();
   }
 
   if (clickableElsInMenu[activeElemIndex] !== undefined && watchedKeyClicked) {
@@ -166,7 +166,7 @@ async function fillTargetWithRelayAddress(generateClickEvt) {
 
   // TODO: Add telemetry event (?)
 
-  await browser.runtime.sendMessage({
+  browser.runtime.sendMessage({
     method: "fillInputWithAlias",
     message: {
       filter: "fillInputWithAlias",
@@ -683,11 +683,11 @@ const buildContent = {
 
     signUpButton.addEventListener("click", async (clickEvt) => {
       preventDefaultBehavior(clickEvt);
-      await browser.runtime.sendMessage({
+      browser.runtime.sendMessage({
         method: "openRelayHomepage",
       });
       sendInPageEvent("click", "input-menu-sign-up-btn");
-      await iframeCloseRelayInPageMenu();
+      iframeCloseRelayInPageMenu();
     });
 
     sendInPageEvent("viewed-menu", "unauthenticated-user-input-menu");
@@ -780,7 +780,7 @@ const buildContent = {
           );
         }
 
-        await browser.runtime.sendMessage({
+        browser.runtime.sendMessage({
           method: "fillInputWithAlias",
           message: {
             filter: "fillInputWithAlias",
@@ -820,7 +820,7 @@ const buildContent = {
       getUnlimitedAliasesBtn.target = "_blank";
       getUnlimitedAliasesBtn.addEventListener("click", async () => {
         sendInPageEvent("click", unlimitedInPageEventId);
-        await iframeCloseRelayInPageMenu();
+        iframeCloseRelayInPageMenu();
       });
     },
     setManageLink: (relaySiteOrigin) => {
@@ -842,7 +842,7 @@ const buildContent = {
 
       relayMenuDashboardLink.addEventListener("click", async () => {
         sendInPageEvent("click", "input-menu-manage-all-aliases-btn");
-        await iframeCloseRelayInPageMenu();
+        iframeCloseRelayInPageMenu();
       });
     },
     search: {

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -1508,7 +1508,7 @@
             "disable-input-icon"
               ? "hide-input-icons"
               : "show-input-icons";
-          await browser.runtime.sendMessage({
+          browser.runtime.sendMessage({
             method: "updateInputIconPref",
             iconPref: userIconPreference,
           });

--- a/src/js/relay.firefox.com/get_profile_data.js
+++ b/src/js/relay.firefox.com/get_profile_data.js
@@ -322,11 +322,11 @@
       }
     });
 
-    await browser.runtime.sendMessage({
+    browser.runtime.sendMessage({
       method: "updateAddOnAuthStatus",
       status: true,
     });
-    await browser.runtime.sendMessage({
+    browser.runtime.sendMessage({
       method: "rebuildContextMenuUpgrade",
     });
   }


### PR DESCRIPTION
See #545 for more context on the issue

- Fix issue where context menus were not created on startup/log-in event
- Remove unnecessary await/sendMessage call when closing the in-page menu
- Remove unnecessary await/sendMessage call when updating the "Show Relay icon on websites" preference
- Remove unnecessary await/sendMessage call when sending metric events
- Fix #545 - Add message explaining the change
