### PR TITLE
initial commit for settings update relating to phone mask feature in …

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -485,9 +485,10 @@ sign-up-panel::after {
 }
 
 #report-feedback-container {
+  /* scroll vertically to give space for new footer */
   max-height: 210px;
   overflow: auto;
-  padding-right: 8px;
+  padding-right: var(--spacingSm);
   width: 100%;
 }
 

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -484,6 +484,13 @@ sign-up-panel::after {
   background: var(--colorInformationalDisabled);
 }
 
+#report-feedback-container {
+  max-height: 210px;
+  overflow: auto;
+  padding-right: 8px;
+  width: 100%;
+}
+
 .report-success {
   padding: var(--spacingMd);
   padding-top: 0;

--- a/src/popup.html
+++ b/src/popup.html
@@ -208,7 +208,7 @@
           <div class="fx-relay-panel-content">
             <div class="fx-relay-settings-toggles">
               <div class="fx-relay-settings-toggle-wrapper">
-                <span class="fx-relay-settings-toggle-label i18n-content" data-i18n-message-id="popupSettingsShowIcon"></span>
+                <span class="fx-relay-settings-toggle-label i18n-content" data-i18n-message-id="popupSettingsShowIconInInputFields"></span>
                 <button title="" data-icon-visibility-option="disable-input-icon" class="toggle-icon-in-page-visibility fx-relay-settings-toggle"></button>
               </div>
               <div class="fx-relay-settings-toggle-wrapper">
@@ -294,18 +294,24 @@
             <form class="report-issue-content">
               <div class="report-section">
                 <label class="report-label i18n-content" for="issue_on_domain" data-i18n-attribute="title"
-                  data-i18n-message-id="popupReportIssueSiteLabelHeadline"></label>
+                  data-i18n-message-id="popupReportIssuesHeadline"></label>
                 <input autocomplete="off" type="text" id="issue_on_domain" name="issue_on_domain" value="" required />
               </div>
-              <div class="report-section">
+              <div id="report-feedback-container" class="report-section">
                 <!-- Select issue checkboxes -->
-                <label class="report-label i18n-content" data-i18n-message-id="popupReportIssueSituationHeadline"></label>
+                <label class="report-label i18n-content" data-i18n-message-id="popupReportFeedbackHeadline"></label>
                 <ul>
                   <li>
                     <!-- Case: Email not accepted -->
                     <input type="checkbox" id="email_mask_not_accepted" name="email_mask_not_accepted" />
                     <label class="i18n-content" for="email_mask_not_accepted"
                       data-i18n-message-id="popupReportIssueCaseOne"></label>
+                  </li>
+                  <li>
+                    <!-- Case: Phone Mask Acceptance issue -->
+                    <input type="checkbox" id="phone_mask_acceptance_issue" name="phone_mask_acceptance_issue" />
+                    <label class="i18n-content" for="phone_mask_acceptance_issue"
+                      data-i18n-message-id="popupReportIssueCaseFour"></label>
                   </li>
                   <li>
                     <!-- Case: Add on visual issue -->
@@ -318,6 +324,12 @@
                     <input type="checkbox" id="email_not_received" name="email_not_received" />
                     <label class="i18n-content" for="email_not_received"
                       data-i18n-message-id="popupReportIssueCaseThree"></label>
+                  </li>
+                  <li>
+                    <!-- Case: Text/Call not received -->
+                    <input type="checkbox" id="text_or_call_not_received" name="text_or_call_not_received" />
+                    <label class="i18n-content" for="text_or_call_not_received"
+                      data-i18n-message-id="popupReportIssueCaseFive"></label>
                   </li>
                   <li>
                     <!-- Case: Other -->


### PR DESCRIPTION
 
<!-- When fixing a bug: -->

This PR fixes MPP-3693 
<!-- When adding a new feature: -->

# New feature description

We currently have a switch that let’s us ask users if we can show the relay icon in email fields on websites. We need to add one that asks the same question but for phone fields. Turning this on and off should control the visibility of the Relay icon on phone fields.
 

Current view: 
![image](https://github.com/mozilla/fx-private-relay-add-on/assets/3924990/9efdb374-311a-4bf5-96dc-b9f697bf0255)


# Screenshot (if applicable)

![image](https://github.com/mozilla/fx-private-relay-add-on/assets/3924990/8f282a4b-081f-4544-8087-b87e68387625)
![image](https://github.com/mozilla/fx-private-relay-add-on/assets/3924990/647320b9-c463-4f4a-8e18-e42b97fd2c59)

# How to test

- Text for input fields setting updated to be inclusive of text/call 
- update issues list for `report issue` section 
- update strings for `report issue` section

# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
