### PR TITLE
feat(limits): fetch free alias limit from backend

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: "Set up node"
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 16
           cache: 'npm'
 
       - name: "Install"

--- a/.github/workflows/sign-and-release-to-github.yml
+++ b/.github/workflows/sign-and-release-to-github.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Create GitHub Deployment
         id: create-deployment
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           script: |
             return await github.rest.repos.createDeployment({
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Mark GitHub Deployment as in progress
         id: start-deployment
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         env:
           DEPLOYMENT_ID: "${{ needs.prepare-deployment.outputs.deployment-id }}"
         with:
@@ -52,13 +52,13 @@ jobs:
             });
 
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: "Update translations"
         run: git submodule update --init --recursive --remote
 
       - name: "Set up node"
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: 'npm'
@@ -116,7 +116,7 @@ jobs:
         id: release_notes
         run: echo 'release_notes=$(git log --no-merges --pretty=format:"%h %s" ${{ steps.version.outputs.version }}^..${{ steps.version.outputs.version }})' >> $GITHUB_OUTPUT;
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: fx-private-relay-stage.xpi
           path: web-ext-artifacts/private_relay-${{ steps.version.outputs.version }}.xpi
@@ -124,13 +124,13 @@ jobs:
       - name: "Configure manifest.json for Chrome build"
         run: npm run config:chrome
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: fx-private-relay-extension.zip
           path: src/
 
       - name: Mark GitHub Deployment as successful
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           script: |
             return await github.rest.repos.createDeploymentStatus({
@@ -146,7 +146,7 @@ jobs:
           DEPLOYMENT_ID: "${{ needs.prepare-deployment.outputs.deployment-id }}"
 
       - name: Mark GitHub Deployment as failed
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         if: failure()
         with:
           script: |

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -1,9 +1,16 @@
-function startupInit() {
+const DEFAULT_MAX_FREE_ALIASES = 5; // Fallback if runtime_data unavailable
+
+async function startupInit() {
   const RELAY_SITE_ORIGIN = "http://127.0.0.1:8000";
   browser.storage.local.set({ RELAY_SITE_ORIGIN });
-  browser.storage.local.set({ maxNumAliases: 5 });
   browser.storage.local.set({ relaySiteOrigin: RELAY_SITE_ORIGIN });
   browser.storage.local.set({ relayApiSource: `${RELAY_SITE_ORIGIN}/api/v1` });
+
+  // Set initial fallback only if not already set
+  const { maxNumAliases } = await browser.storage.local.get("maxNumAliases");
+  if (maxNumAliases === undefined) {
+    browser.storage.local.set({ maxNumAliases: DEFAULT_MAX_FREE_ALIASES });
+  }
 }
 
 browser.runtime.onStartup.addListener(startupInit);
@@ -185,7 +192,8 @@ async function storeRuntimeData(opts={forceUpdate: false}) {
     periodicalPremiumProductId: {
       PERIODICAL_PREMIUM_PRODUCT_ID: runtimeData.PERIODICAL_PREMIUM_PRODUCT_ID,
       fetchedAt: Date.now(),
-    }
+    },
+    maxNumAliases: runtimeData.MAX_NUM_FREE_ALIASES || DEFAULT_MAX_FREE_ALIASES
   })
 }
 
@@ -574,7 +582,7 @@ browser.runtime.onMessage.addListener((m, sender, sendResponse) => {
 });
 
 (async () => {
-  startupInit();
+  await startupInit();
   await displayBrowserActionBadge();
-  storeRuntimeData();
+  await storeRuntimeData();
 })();


### PR DESCRIPTION
The backend exposes `MAX_NUM_FREE_ALIASES` via `runtime_data`. Product can now adjust the free tier limit without rebuilding the add-on. Add-on falls back to 5 if the backend is unavailable.

<!-- The following is intended to be helpful to you. Feel free to remove anything that is not. -->

<!-- When fixing a bug: -->

This PR fixes #<issue ID>.

How to test:

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description



# Screenshot (if applicable)

Not applicable.

# How to test



# Checklist

- [ ] l10n changes have been submitted to the l10n repository, if any.
- [ ] All acceptance criteria are met.
- [ ] All UI revisions follow the [coding standards](https://github.com/mozilla/fx-private-relay/blob/main/docs/coding-standards.md), and use Protocol tokens where applicable (see `/frontend/src/styles/tokens.scss`).
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
