### PR TITLE
[codex] Add Chrome Manifest V3 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ These scripts will build the add-on to work with dev, stage, or prod servers.
 If you want to run the Chrome build of the add-on, use the following scripts:
  
 > [!NOTE]  
-> It runs the same scripts as above, but also edits the [`menus`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus) permission listed in the manifest.json*
+> It runs the same scripts as above, but also converts `manifest.json` to Chrome's Manifest V3 format.
  
  * `npm run build:chrome-dev`: https://dev.fxprivaterelay.nonprod.cloudops.mozgcp.net/
  * `npm run build:chrome-stage`: https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net/
@@ -217,4 +217,3 @@ Finally, we also publish the release to GitHub for those followers.
    * Use the version number for "Tag version" and "Release title"
    * Release notes: copy the output of `git log --no-merges --pretty=format:"%h %s" <previous-version>..<new-version>`
    * Attach binaries: select the signed `.xpi` file
-

--- a/config-chrome.sh
+++ b/config-chrome.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
 # script to run the sed commands in both OSX and linux (e.g., GitHub Action)
-# remove "contextMenus" permission (Firefox-only) from manifest.json
-# Note: the last permission cannot be "menus" or the JSON file will create a linter error
+# Convert the checked-in Firefox manifest to a Chrome MV3 manifest.
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "/menus/d" src/manifest.json
-else
-    sed -i "/menus/d" src/manifest.json
-fi
+node scripts/config-chrome.js

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "config:prod": "npm run build:clean && ./config-domain.sh https://relay.firefox.com",
     "dev": "npm run web-ext-run",
     "lint": "eslint src && web-ext build -s src/ -n firefox_relay.zip --overwrite-dest && web-ext lint -s web-ext-artifacts/firefox_relay.zip && rm -f web-ext-artifacts/firefox_relay.zip",
-    "package:chrome": "zip -r web-ext-artifacts/chrome_relay-${npm_package_version}.zip ./src",
+    "package:chrome": "web-ext build -s src/ -n chrome_relay-${npm_package_version}.zip --overwrite-dest",
     "test": "echo \"Error: no test specified\" && exit 1",
     "restore-locales-github": "cd src/_locales && git restore .github/workflows/update-upstream-relay-repo.yml",
     "remove-locales-github": "rm -rf src/_locales/.github",

--- a/scripts/config-chrome.js
+++ b/scripts/config-chrome.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const manifestPath = path.join(__dirname, "..", "src", "manifest.json");
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+function isHostPermission(permission) {
+  return permission === "<all_urls>" || /^[a-z*]+:\/\/.+/.test(permission);
+}
+
+manifest.manifest_version = 3;
+
+manifest.background = {
+  service_worker: "js/background/service-worker.js",
+};
+
+if (manifest.browser_action) {
+  manifest.action = {
+    default_icon: manifest.browser_action.default_icon,
+    default_popup: manifest.browser_action.default_popup,
+  };
+  delete manifest.browser_action;
+}
+
+delete manifest.browser_specific_settings;
+
+const permissions = manifest.permissions ?? [];
+const hostPermissions = new Set(manifest.host_permissions ?? []);
+manifest.permissions = permissions.filter((permission) => {
+  if (permission === "menus") {
+    return false;
+  }
+
+  if (isHostPermission(permission)) {
+    hostPermissions.add(permission);
+    return false;
+  }
+
+  return true;
+});
+
+if (hostPermissions.size > 0) {
+  manifest.host_permissions = Array.from(hostPermissions);
+}
+
+if (
+  Array.isArray(manifest.web_accessible_resources) &&
+  manifest.web_accessible_resources.every((resource) => typeof resource === "string")
+) {
+  manifest.web_accessible_resources = [
+    {
+      resources: manifest.web_accessible_resources,
+      matches: ["<all_urls>"],
+    },
+  ];
+}
+
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/src/js/background/background.js
+++ b/src/js/background/background.js
@@ -6,6 +6,8 @@ function startupInit() {
   browser.storage.local.set({ relayApiSource: `${RELAY_SITE_ORIGIN}/api/v1` });
 }
 
+/* global getRelayBrowserAction */
+
 browser.runtime.onStartup.addListener(startupInit);
 
 browser.runtime.onInstalled.addListener((details) => {
@@ -494,10 +496,15 @@ async function displayBrowserActionBadge() {
   }
 
   if (!browserActionBadgesClicked && (serverStoragePrompt !== true || privacyNoticeUpdatePromptShown !== true)) {
-    browser.browserAction.setBadgeBackgroundColor({
+    const browserAction = getRelayBrowserAction();
+    if (!browserAction) {
+      return;
+    }
+
+    browserAction.setBadgeBackgroundColor({
       color: "#00D900",
     });
-    browser.browserAction.setBadgeText({ text: "!" });
+    browserAction.setBadgeText({ text: "!" });
   }
 }
 

--- a/src/js/background/service-worker.js
+++ b/src/js/background/service-worker.js
@@ -1,0 +1,8 @@
+/* global importScripts */
+
+importScripts(
+  "../libs/browser-polyfill.min.js",
+  "../shared/utils.js",
+  "background.js",
+  "context-menu.js"
+);

--- a/src/js/popup/popup.js
+++ b/src/js/popup/popup.js
@@ -1,4 +1,4 @@
-/* global getBrowser checkWaffleFlag psl */
+/* global getBrowser checkWaffleFlag getRelayBrowserAction psl */
 
 (async () => {
   // Global Data
@@ -1475,8 +1475,10 @@
         // Dismiss the browserActionBadge only when it exists
         if (browserActionBadgesClicked === false) {
           browser.storage.local.set({ browserActionBadgesClicked: true });
-          browser.browserAction.setBadgeBackgroundColor({ color: null });
-          browser.browserAction.setBadgeText({ text: "" });
+          const browserAction = getRelayBrowserAction();
+          if (browserAction) {
+            browserAction.setBadgeText({ text: "" });
+          }
         }
       },
       enableInputIconDisabling: async () => {

--- a/src/js/shared/utils.js
+++ b/src/js/shared/utils.js
@@ -1,4 +1,4 @@
-/* exported areInputIconsEnabled setCustomFonts preventDefaultBehavior checkWaffleFlag getBrowser */
+/* exported areInputIconsEnabled setCustomFonts preventDefaultBehavior checkWaffleFlag getBrowser getRelayBrowserAction */
 
 // eslint-disable-next-line no-redeclare
 async function areInputIconsEnabled() {
@@ -65,4 +65,8 @@ async function getBrowser() {
     return "Firefox";
   }
   return "Chrome";
+}
+
+function getRelayBrowserAction() {
+  return browser.action ?? browser.browserAction;
 }


### PR DESCRIPTION
## Summary

Fixes #558.

- Converts the Chrome build path to generate a Manifest V3 manifest with a service-worker background, `action`, `host_permissions`, and MV3 `web_accessible_resources`.
- Adds a Chrome MV3 service worker entry that loads the existing background scripts in the same order as the Firefox MV2 manifest.
- Uses a shared action API helper so badge code works with both `browser.browserAction` and `browser.action`.
- Builds the Chrome-named archive with `web-ext build` so the package has `manifest.json` at the zip root.

## Validation

- `npm run lint`
- `npm run config:chrome`
- Chrome MV3 manifest assertion with `node -e`
- `npm run build:dirty`
- `npm run package:chrome`
- Confirmed `web-ext-artifacts/chrome_relay-2.8.1.zip` contains root `manifest.json`
- Playwright Chromium extension load test:
  - MV3 service worker started at `chrome-extension://okgkaflholpmmbkocknokliapajemhae/js/background/service-worker.js`
  - `popup.html` rendered with title `Firefox Relay`
- Playwright Chromium feature smoke test:
  - startup storage initialized `RELAY_SITE_ORIGIN`, `relaySiteOrigin`, `relayApiSource`, and `maxNumAliases`
  - `browser.action` badge compatibility set badge text to `!`
  - signed-out popup rendered the sign-in panel and Relay sign-in link
  - content scripts injected the Relay email-field icon and accessible button on a local email form
  - clicking the injected icon opened the in-page panel iframe
  - context-menu fill messaging populated the email field with `mask@example.com`
  - context-menu creation path created `fx-private-relay-generate-alias` and `fx-private-relay-manage-aliases`
